### PR TITLE
feat: Improved documentation about batching, WriteOptions, WriteType should be in separate file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.3.0 [unreleased]
 
+### Documentation
+
+1. [#22](https://github.com/influxdata/influxdb-client-php/pull/24): Improved documentation about batching
+
 ## 1.2.0 [2020-04-17]
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Documentation
 
-1. [#22](https://github.com/influxdata/influxdb-client-php/pull/24): Improved documentation about batching
+1. [#24](https://github.com/influxdata/influxdb-client-php/pull/24): Improved documentation about batching
 
 ## 1.2.0 [2020-04-17]
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,6 @@ $write_api = $client->createWriteApi();
 $write_api->write('h2o,location=west value=33i 15');
 ```
 
-<!--- TODO still in progress
 #### Batching
 
 The writes are processed in batches which are configurable by `WriteOptions`:
@@ -153,18 +152,25 @@ The writes are processed in batches which are configurable by `WriteOptions`:
 | **flushInterval** | the number of milliseconds before the batch is written | 1000 |
 
 ```php
-$client = new InfluxDB2\Client(["url" => "http://localhost:9999", "token" => "my-token",
+use InfluxDB2\Client;
+use InfluxDB2\WriteType as WriteType;
+
+$client = new Client(["url" => "http://localhost:9999", "token" => "my-token",
     "bucket" => "my-bucket",
     "org" => "my-org",
     "precision" => InfluxDB2\Model\WritePrecision::NS
 ]);
 
 $writeApi = $client->createWriteApi(
-    ["writeType"=>InfluxDB2\WriteType::BATCHING, 'batchSize'=>1000, "flushInterval" =>1000]);
+    ["writeType" => WriteType::BATCHING, 'batchSize' => 1000, "flushInterval" => 1000]);
 
-$writeApi->write('h2o,location=west value=33i 15');
+foreach (range(1, 10000) as $number) {
+    $writeApi->write("mem,host=aws_europe,type=batch value=1i $number");
+}
+
+// flush remaining data
+$writeApi->close();
 ```
--->
 
 #### Time precision
 

--- a/examples/WriteBatchingExample.php
+++ b/examples/WriteBatchingExample.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Shows how to use batching for more performance writes.
+ */
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use InfluxDB2\Client;
+use InfluxDB2\WriteType as WriteType;
+
+$organization = 'my-org';
+$bucket = 'my-bucket';
+$token = 'my-token';
+
+$client = new Client([
+    "url" => "http://localhost:9999",
+    "token" => $token,
+    "bucket" => $bucket,
+    "org" => $organization,
+    "precision" => InfluxDB2\Model\WritePrecision::S
+]);
+
+print  "*** Write by batching ***\n";
+
+$writeApi = $client->createWriteApi(
+    ["writeType" => WriteType::BATCHING, 'batchSize' => 1000, "flushInterval" => 1000]);
+
+foreach (range(1, 10000) as $number) {
+    $writeApi->write("mem,host=aws_europe,type=batch value=1i $number");
+}
+
+// flush remaining data
+$client->close();
+
+print  "*** Check result ***\n";
+
+$queryApi = $client->createQueryApi();
+$query = "from(bucket: \"$bucket\") 
+    |> range(start: 0) 
+    |> filter(fn: (r) => r[\"_measurement\"] == \"mem\") 
+    |> filter(fn: (r) => r[\"host\"] == \"aws_europe\") 
+    |> count()";
+$tables = $queryApi->query($query);
+$record = $tables[0]->records[0];
+$value = $record->getValue();
+print "Count: $value\n";
+
+$client->close();
+

--- a/src/InfluxDB2/WriteApi.php
+++ b/src/InfluxDB2/WriteApi.php
@@ -5,39 +5,6 @@ namespace InfluxDB2;
 
 use InfluxDB2\Model\WritePrecision;
 
-class WriteType
-{
-    const SYNCHRONOUS = 1;
-    const BATCHING = 2;
-}
-
-class WriteOptions
-{
-    const DEFAULT_BATCH_SIZE = 10;
-    const DEFAULT_FLUSH_INTERVAL = 1000;
-
-    public $writeType;
-    public $batchSize;
-    public $flushInterval;
-
-    /**
-     * WriteOptions constructor.
-     *      $writeOptions = [
-     *          'writeType' => methods of write (WriteType::SYNCHRONOUS - default, WriteType::BATCHING)
-     *          'batchSize' => the number of data point to collect in batch
-     *          'flushInterval' => flush data at least in this interval
-     *      ]
-     * @param array $writeOptions Array containing the write parameters (See above)
-     */
-    public function __construct(array $writeOptions = null)
-    {
-        //initialize with default values
-        $this->writeType =  $writeOptions["writeType"] ?: WriteType::SYNCHRONOUS;
-        $this->batchSize = $writeOptions["batchSize"] ?:  self::DEFAULT_BATCH_SIZE;
-        $this->flushInterval = $writeOptions["flushInterval"] ?:  self::DEFAULT_FLUSH_INTERVAL;
-    }
-}
-
 /**
  * Write time series data into InfluxDB.
  * @package InfluxDB2

--- a/src/InfluxDB2/WriteOptions.php
+++ b/src/InfluxDB2/WriteOptions.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace InfluxDB2;
+
+class WriteOptions
+{
+    const DEFAULT_BATCH_SIZE = 10;
+    const DEFAULT_FLUSH_INTERVAL = 1000;
+
+    public $writeType;
+    public $batchSize;
+    public $flushInterval;
+
+    /**
+     * WriteOptions constructor.
+     *      $writeOptions = [
+     *          'writeType' => methods of write (WriteType::SYNCHRONOUS - default, WriteType::BATCHING)
+     *          'batchSize' => the number of data point to collect in batch
+     *          'flushInterval' => flush data at least in this interval
+     *      ]
+     * @param array $writeOptions Array containing the write parameters (See above)
+     */
+    public function __construct(array $writeOptions = null)
+    {
+        //initialize with default values
+        $this->writeType =  $writeOptions["writeType"] ?: WriteType::SYNCHRONOUS;
+        $this->batchSize = $writeOptions["batchSize"] ?:  self::DEFAULT_BATCH_SIZE;
+        $this->flushInterval = $writeOptions["flushInterval"] ?:  self::DEFAULT_FLUSH_INTERVAL;
+    }
+}
+

--- a/src/InfluxDB2/WriteType.php
+++ b/src/InfluxDB2/WriteType.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace InfluxDB2;
+
+class WriteType
+{
+    const SYNCHRONOUS = 1;
+    const BATCHING = 2;
+}


### PR DESCRIPTION
Closes #23

1. Improved documentation about batching
2. `WriteOptions`, `WriteType` should be in an separate file - [see PSR-4: Autoloader](https://www.php-fig.org/psr/psr-4/)

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)