### PR TITLE
fix: serialization of `\n`, `\r` and `\t` to Line Protocol, `=` is valid sign for measurement name 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Features
 1. [#29](https://github.com/influxdata/influxdb-client-php/issues/29): Prevent invalid array access when no write options are passed to the WriteApi.
 
+### Bug Fixes
+1. [#27](https://github.com/influxdata/influxdb-client-php/pull/27): Fixed serialization of `\n`, `\r` and `\t` to Line Protocol 
+
 ## 1.4.0 [2020-06-19]
 
 ### API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 1. [#29](https://github.com/influxdata/influxdb-client-php/issues/29): Prevent invalid array access when no write options are passed to the WriteApi.
 
 ### Bug Fixes
-1. [#27](https://github.com/influxdata/influxdb-client-php/pull/27): Fixed serialization of `\n`, `\r` and `\t` to Line Protocol 
+1. [#27](https://github.com/influxdata/influxdb-client-php/pull/27): Fixed serialization of `\n`, `\r` and `\t` to Line Protocol, `=` is valid sign for measurement name  
 
 ## 1.4.0 [2020-06-19]
 

--- a/src/InfluxDB2/Point.php
+++ b/src/InfluxDB2/Point.php
@@ -117,7 +117,7 @@ class Point
      */
     public function toLineProtocol()
     {
-        $measurement = $this->escapeKey($this->name);
+        $measurement = $this->escapeKey($this->name, false);
 
         $lineProtocol = $measurement;
 
@@ -260,11 +260,15 @@ class Point
         return ' ' . $time;
     }
 
-    private function escapeKey($key)
+    private function escapeKey($key, $escapeEqual = true)
     {
-        $escapeKeys = array(' ' => '\\ ', ',' => '\\,', '=' => '\\=', "\\" => '\\\\',
+        $escapeKeys = array(' ' => '\\ ', ',' => '\\,', "\\" => '\\\\',
             "\n" => '\\n', "\r" => '\\r', "\t" => '\\t');
-        
+
+        if ($escapeEqual) {
+            $escapeKeys['='] = '\\=';
+        }
+
         return strtr($key, $escapeKeys);
     }
 

--- a/src/InfluxDB2/Point.php
+++ b/src/InfluxDB2/Point.php
@@ -262,7 +262,9 @@ class Point
 
     private function escapeKey($key)
     {
-        $escapeKeys = array(' ' => '\\ ', ',' => '\\,', '=' => '\\=', "\\" => '\\\\');
+        $escapeKeys = array(' ' => '\\ ', ',' => '\\,', '=' => '\\=', "\\" => '\\\\',
+            "\n" => '\\n', "\r" => '\\r', "\t" => '\\t');
+        
         return strtr($key, $escapeKeys);
     }
 

--- a/tests/PointTest.php
+++ b/tests/PointTest.php
@@ -57,6 +57,18 @@ class PointTest extends TestCase
         $this->assertEquals('h2o,location=europe level=2i', $point->toLineProtocol());
     }
 
+    public function testTagEscapingKeyAndValue()
+    {
+        $point =  Point::measurement("h\n2\ro\t_data")
+                ->addTag("new\nline", "new\nline")
+                ->addTag("carriage\rreturn", "carriage\nreturn")
+                ->addTag("t\tab", "t\tab")
+                ->addField("level", 2);
+
+        $this->assertEquals("h\\n2\\ro\\t_data,carriage\\rreturn=carriage\\nreturn,new\\nline=new\\nline,t\\tab=t\\tab level=2i",
+            $point->toLineProtocol());
+    }
+
     public function testOverrideTagAndField()
     {
         $point = Point::measurement('h2o')

--- a/tests/PointTest.php
+++ b/tests/PointTest.php
@@ -69,6 +69,15 @@ class PointTest extends TestCase
             $point->toLineProtocol());
     }
 
+    public function testEqualSignEscaping() {
+
+        $point =  Point::measurement("h=2o")
+                ->addTag("l=ocation", "e=urope")
+                ->addField("l=evel", 2);
+
+        $this->assertEquals("h=2o,l\\=ocation=e\\=urope l\\=evel=2i", $point->toLineProtocol());
+    }
+
     public function testOverrideTagAndField()
     {
         $point = Point::measurement('h2o')


### PR DESCRIPTION
Related to https://github.com/influxdata/influxdb-client-java/issues/127

* serialization of `\n`, `\r` and `\t` to Line Protocol
* `=` is valid sign for measurement name 

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)