### PR TITLE
update for php 7.4 compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,6 +105,9 @@ workflows:
   build:
     jobs:
       - tests-php:
+          name: php-7.4
+          php-image: "circleci/php:7.4"
+      - tests-php:
           name: php-7.3
       - tests-php:
           name: php-7.3-nightly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.5.0 [unreleased]
 
-### Bug Fixes
+### Features
 1. [#29](https://github.com/influxdata/influxdb-client-php/issues/29): Prevent invalid array access when no write options are passed to the WriteApi.
 
 ## 1.4.0 [2020-06-19]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 1.5.0 [unreleased]
 
+1. [#29](https://github.com/influxdata/influxdb-client-php/issues/29): Prevent invalid array access when no write options are passed to the WriteApi.
+
 ## 1.4.0 [2020-06-19]
 
 ### API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.5.0 [unreleased]
 
+### Bug Fixes
 1. [#29](https://github.com/influxdata/influxdb-client-php/issues/29): Prevent invalid array access when no write options are passed to the WriteApi.
 
 ## 1.4.0 [2020-06-19]

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "~2.12",
-    "phpspec/phpspec": "^5.0",
+    "phpspec/phpspec": ">5.0",
     "phpunit/phpunit": "^7.4",
     "squizlabs/php_codesniffer": "~2.6"
   },

--- a/src/InfluxDB2/WriteOptions.php
+++ b/src/InfluxDB2/WriteOptions.php
@@ -23,9 +23,9 @@ class WriteOptions
     public function __construct(array $writeOptions = null)
     {
         //initialize with default values
-        $this->writeType =  $writeOptions["writeType"] ?: WriteType::SYNCHRONOUS;
-        $this->batchSize = $writeOptions["batchSize"] ?:  self::DEFAULT_BATCH_SIZE;
-        $this->flushInterval = $writeOptions["flushInterval"] ?:  self::DEFAULT_FLUSH_INTERVAL;
+        $this->writeType =  $writeOptions["writeType"] ?? WriteType::SYNCHRONOUS;
+        $this->batchSize = $writeOptions["batchSize"] ??  self::DEFAULT_BATCH_SIZE;
+        $this->flushInterval = $writeOptions["flushInterval"] ??  self::DEFAULT_FLUSH_INTERVAL;
     }
 }
 


### PR DESCRIPTION
Closes #29 

This commit prevents invalid container access
by properly checking access in the respective places.

Also adds a CI test and updates dependencies for php 7.4.
Phpspec decided to not have a single version that's compatible with `php7.1` through `php7.4`, so I had to make the version constraint less restrictive. I hope thats fine.

- [X] CHANGELOG.md updated
- [X] Rebased/mergeable
- [X] Tests pass
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)