### PR TITLE
feat: Added retryInterval, maxRetries and maxRetryDelay to WriteApi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.6.0 [unreleased]
 
+### Features
+1. [#32](https://github.com/influxdata/influxdb-client-php/pull/32): Added retryInterval and maxRetries to WriteOptions in WriteApi
+
 ## 1.5.0 [2020-07-17]
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.6.0 [unreleased]
 
 ### Features
-1. [#32](https://github.com/influxdata/influxdb-client-php/pull/32): Added retryInterval and maxRetries to WriteOptions in WriteApi
+1. [#32](https://github.com/influxdata/influxdb-client-php/pull/32): Added retryInterval, maxRetries and maxRetryDelay to WriteOptions in WriteApi
 
 ## 1.5.0 [2020-07-17]
 

--- a/README.md
+++ b/README.md
@@ -150,8 +150,9 @@ The writes are processed in batches which are configurable by `WriteOptions`:
 | **writeType** | type of write SYNCHRONOUS / BATCHING /  | SYNCHRONOUS |
 | **batchSize** | the number of data point to collect in batch | 10 |
 | **flushInterval** | the number of milliseconds before the batch is written | 1000 |
-| **retryInterval** | the number of milliseconds to retry unsuccessful write. The retry interval is used when the InfluxDB server does not specify "Retry-After" header. | 1000 |
+| **retryInterval** | the number of milliseconds to retry unsuccessful write. The retry interval is "exponentially" used when the InfluxDB server does not specify "Retry-After" header. | 1000 |
 | **maxRetries** | the number of max retries when write fails | 3 |
+| **maxRetryDelay** | maximum delay when retrying write | 15000 |
 
 ```php
 use InfluxDB2\Client;

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ The writes are processed in batches which are configurable by `WriteOptions`:
 | **flushInterval** | the number of milliseconds before the batch is written | 1000 |
 | **retryInterval** | the number of milliseconds to retry unsuccessful write. The retry interval is "exponentially" used when the InfluxDB server does not specify "Retry-After" header. | 1000 |
 | **maxRetries** | the number of max retries when write fails | 3 |
-| **maxRetryDelay** | maximum delay when retrying write | 15000 |
+| **maxRetryDelay** | maximum delay when retrying write in milliseconds | 15000 |
 
 ```php
 use InfluxDB2\Client;

--- a/README.md
+++ b/README.md
@@ -148,8 +148,10 @@ The writes are processed in batches which are configurable by `WriteOptions`:
 | Property | Description | Default Value |
 | --- | --- | --- |
 | **writeType** | type of write SYNCHRONOUS / BATCHING /  | SYNCHRONOUS |
-| **batchSize** | the number of data point to collect in batch | 1000 |
+| **batchSize** | the number of data point to collect in batch | 10 |
 | **flushInterval** | the number of milliseconds before the batch is written | 1000 |
+| **retryInterval** | the number of milliseconds to retry unsuccessful write. The retry interval is used when the InfluxDB server does not specify "Retry-After" header. | 1000 |
+| **maxRetries** | the number of max retries when write fails | 3 |
 
 ```php
 use InfluxDB2\Client;

--- a/src/InfluxDB2/WriteApi.php
+++ b/src/InfluxDB2/WriteApi.php
@@ -125,7 +125,7 @@ class WriteApi extends DefaultApi
                 $timeout = $this->writeOptions->retryInterval * 1000.0;
             }
 
-            usleep($timeout . "\n");
+            usleep($timeout);
 
             $this->writeRawInternal($data, $queryParams, $attempts + 1);
         }

--- a/src/InfluxDB2/WriteOptions.php
+++ b/src/InfluxDB2/WriteOptions.php
@@ -8,12 +8,14 @@ class WriteOptions
     const DEFAULT_FLUSH_INTERVAL = 1000;
     const DEFAULT_RETRY_INTERVAL = 1000;
     const DEFAULT_MAX_RETRIES = 3;
+    const DEFAULT_MAX_RETRY_DELAY = 15000;
 
     public $writeType;
     public $batchSize;
     public $flushInterval;
     public $retryInterval;
     public $maxRetries;
+    public $maxRetryDelay;
 
     /**
      * WriteOptions constructor.
@@ -24,6 +26,7 @@ class WriteOptions
      *          'retryInterval' => number of milliseconds to retry unsuccessful write
      *          'maxRetries' => max number of retries when write fails
      *              The retry interval is used when the InfluxDB server does not specify "Retry-After" header.
+     *          'maxRetryDelay' => maximum delay when retrying write
      *      ]
      * @param array $writeOptions Array containing the write parameters (See above)
      */
@@ -35,6 +38,7 @@ class WriteOptions
         $this->flushInterval = $writeOptions["flushInterval"] ??  self::DEFAULT_FLUSH_INTERVAL;
         $this->retryInterval = $writeOptions["retryInterval"] ?? self::DEFAULT_RETRY_INTERVAL;
         $this->maxRetries = $writeOptions["maxRetries"] ?? self::DEFAULT_MAX_RETRIES;
+        $this->maxRetryDelay = $writeOptions["maxRetryDelay"] ?? self::DEFAULT_MAX_RETRY_DELAY;
     }
 }
 

--- a/src/InfluxDB2/WriteOptions.php
+++ b/src/InfluxDB2/WriteOptions.php
@@ -6,10 +6,14 @@ class WriteOptions
 {
     const DEFAULT_BATCH_SIZE = 10;
     const DEFAULT_FLUSH_INTERVAL = 1000;
+    const DEFAULT_RETRY_INTERVAL = 1000;
+    const DEFAULT_MAX_RETRIES = 3;
 
     public $writeType;
     public $batchSize;
     public $flushInterval;
+    public $retryInterval;
+    public $maxRetries;
 
     /**
      * WriteOptions constructor.
@@ -17,6 +21,9 @@ class WriteOptions
      *          'writeType' => methods of write (WriteType::SYNCHRONOUS - default, WriteType::BATCHING)
      *          'batchSize' => the number of data point to collect in batch
      *          'flushInterval' => flush data at least in this interval
+     *          'retryInterval' => number of milliseconds to retry unsuccessful write
+     *          'maxRetries' => max number of retries when write fails
+     *              The retry interval is used when the InfluxDB server does not specify "Retry-After" header.
      *      ]
      * @param array $writeOptions Array containing the write parameters (See above)
      */
@@ -26,6 +33,8 @@ class WriteOptions
         $this->writeType =  $writeOptions["writeType"] ?? WriteType::SYNCHRONOUS;
         $this->batchSize = $writeOptions["batchSize"] ??  self::DEFAULT_BATCH_SIZE;
         $this->flushInterval = $writeOptions["flushInterval"] ??  self::DEFAULT_FLUSH_INTERVAL;
+        $this->retryInterval = $writeOptions["retryInterval"] ?? self::DEFAULT_RETRY_INTERVAL;
+        $this->maxRetries = $writeOptions["maxRetries"] ?? self::DEFAULT_MAX_RETRIES;
     }
 }
 

--- a/tests/WriteApiBatchingTest.php
+++ b/tests/WriteApiBatchingTest.php
@@ -6,6 +6,7 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use InfluxDB2\ApiException;
 use InfluxDB2\WriteType;
 use Webmozart\Assert\Assert;
 
@@ -121,5 +122,66 @@ class WriteApiBatchingTest extends BasicTest
         $this->assertEquals("h2o_feet,location=coyote_creek level\\ water_level=1.0 1\n"
             . "h2o_feet,location=coyote_creek level\\ water_level=2.0 2\n"
             . 'h2o_feet,location=coyote_creek level\\ water_level=3.0 3', $request->getBody());
+    }
+
+    public function testRetryIntervalByConfig()
+    {
+        $errorBody = '{"code":"temporarily unavailable","message":"Token is temporarily over quota.'
+            . 'The Retry-After header describes when to try the write again."}';
+
+        $this->mockHandler->append(new Response(429, ['X-Platform-Error-Code' => 'temporarily unavailable'],
+            $errorBody), new Response(204));
+
+        $this->writeApi->write('h2o_feet,location=coyote_creek water_level=1.0 1');
+        $this->writeApi->write('h2o_feet,location=coyote_creek water_level=2.0 2');
+
+        $this->assertEquals(2, count($this->container));
+        $request = $this->mockHandler->getLastRequest();
+
+        $this->assertEquals('http://localhost:9999/api/v2/write?org=my-org&bucket=my-bucket&precision=ns',
+            strval($request->getUri()));
+        $this->assertEquals("h2o_feet,location=coyote_creek water_level=1.0 1\n"
+            . "h2o_feet,location=coyote_creek water_level=2.0 2", $request->getBody()->getContents());
+    }
+
+    public function testRetryIntervalByHeader()
+    {
+        $errorBody = '{"code":"temporarily unavailable","message":"Token is temporarily over quota.'
+            . 'The Retry-After header describes when to try the write again."}';
+
+        $this->mockHandler->append(new Response(429, ['X-Platform-Error-Code' => 'temporarily unavailable',
+            'Retry-After' => '3'],
+            $errorBody), new Response(204));
+
+        $this->writeApi->write('h2o_feet,location=coyote_creek water_level=1.0 1');
+        $this->writeApi->write('h2o_feet,location=coyote_creek water_level=2.0 2');
+
+        $this->assertEquals(2, count($this->container));
+        $request = $this->mockHandler->getLastRequest();
+
+        $this->assertEquals('http://localhost:9999/api/v2/write?org=my-org&bucket=my-bucket&precision=ns',
+            strval($request->getUri()));
+        $this->assertEquals("h2o_feet,location=coyote_creek water_level=1.0 1\n"
+            . "h2o_feet,location=coyote_creek water_level=2.0 2", $request->getBody()->getContents());
+    }
+
+    public function testRetryIntervalMaxRetries()
+    {
+        $errorBody = '{"code":"temporarily unavailable","message":"Token is temporarily over quota.'
+            . 'The Retry-After header describes when to try the write again."}';
+
+        $this->writeApi->writeOptions->maxRetries = 2;
+
+        $this->mockHandler->append(
+            new Response(429, ['X-Platform-Error-Code' => 'temporarily unavailable'], $errorBody),
+            new Response(429, ['X-Platform-Error-Code' => 'temporarily unavailable'], $errorBody),
+            new Response(429, ['X-Platform-Error-Code' => 'temporarily unavailable'], $errorBody));
+
+        $this->expectException(ApiException::class);
+
+        $this->writeApi->write('h2o_feet,location=coyote_creek water_level=1.0 1');
+        $this->writeApi->write('h2o_feet,location=coyote_creek water_level=2.0 2');
+
+        $this->assertEquals(3, count($this->container));
     }
 }


### PR DESCRIPTION
Closes

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `make test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
