### PR TITLE
fix: Removed unused flushInterval from WriteApi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Features
 1. [#32](https://github.com/influxdata/influxdb-client-php/pull/32): Added retryInterval, maxRetries and maxRetryDelay to WriteOptions in WriteApi
 
+### Bug Fixes
+1. [#33](https://github.com/influxdata/influxdb-client-php/pull/33): Removed unused flushInterval from WriteApi
+
 ## 1.5.0 [2020-07-17]
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -149,7 +149,6 @@ The writes are processed in batches which are configurable by `WriteOptions`:
 | --- | --- | --- |
 | **writeType** | type of write SYNCHRONOUS / BATCHING /  | SYNCHRONOUS |
 | **batchSize** | the number of data point to collect in batch | 10 |
-| **flushInterval** | the number of milliseconds before the batch is written | 1000 |
 | **retryInterval** | the number of milliseconds to retry unsuccessful write. The retry interval is "exponentially" used when the InfluxDB server does not specify "Retry-After" header. | 1000 |
 | **maxRetries** | the number of max retries when write fails | 3 |
 | **maxRetryDelay** | maximum delay when retrying write in milliseconds | 15000 |
@@ -165,7 +164,7 @@ $client = new Client(["url" => "http://localhost:9999", "token" => "my-token",
 ]);
 
 $writeApi = $client->createWriteApi(
-    ["writeType" => WriteType::BATCHING, 'batchSize' => 1000, "flushInterval" => 1000]);
+    ["writeType" => WriteType::BATCHING, 'batchSize' => 1000]);
 
 foreach (range(1, 10000) as $number) {
     $writeApi->write("mem,host=aws_europe,type=batch value=1i $number");

--- a/examples/WriteBatchingExample.php
+++ b/examples/WriteBatchingExample.php
@@ -23,7 +23,7 @@ $client = new Client([
 print  "*** Write by batching ***\n";
 
 $writeApi = $client->createWriteApi(
-    ["writeType" => WriteType::BATCHING, 'batchSize' => 1000, "flushInterval" => 1000]);
+    ["writeType" => WriteType::BATCHING, 'batchSize' => 1000]);
 
 foreach (range(1, 10000) as $number) {
     $writeApi->write("mem,host=aws_europe,type=batch value=1i $number");

--- a/src/InfluxDB2/Client.php
+++ b/src/InfluxDB2/Client.php
@@ -39,7 +39,6 @@ class Client
      *      $writeOptions = [
      *          'writeType' => methods of write (WriteType::SYNCHRONOUS - default, WriteType::BATCHING)
      *          'batchSize' => the number of data point to collect in batch
-     *          'flushInterval' => flush data at least in this interval
      *      ]
      * @param array|null $writeOptions Array containing the write parameters (See above)
      * @return WriteApi

--- a/src/InfluxDB2/WriteOptions.php
+++ b/src/InfluxDB2/WriteOptions.php
@@ -5,14 +5,12 @@ namespace InfluxDB2;
 class WriteOptions
 {
     const DEFAULT_BATCH_SIZE = 10;
-    const DEFAULT_FLUSH_INTERVAL = 1000;
     const DEFAULT_RETRY_INTERVAL = 1000;
     const DEFAULT_MAX_RETRIES = 3;
     const DEFAULT_MAX_RETRY_DELAY = 15000;
 
     public $writeType;
     public $batchSize;
-    public $flushInterval;
     public $retryInterval;
     public $maxRetries;
     public $maxRetryDelay;
@@ -22,7 +20,6 @@ class WriteOptions
      *      $writeOptions = [
      *          'writeType' => methods of write (WriteType::SYNCHRONOUS - default, WriteType::BATCHING)
      *          'batchSize' => the number of data point to collect in batch
-     *          'flushInterval' => flush data at least in this interval
      *          'retryInterval' => number of milliseconds to retry unsuccessful write
      *          'maxRetries' => max number of retries when write fails
      *              The retry interval is used when the InfluxDB server does not specify "Retry-After" header.
@@ -35,7 +32,6 @@ class WriteOptions
         //initialize with default values
         $this->writeType =  $writeOptions["writeType"] ?? WriteType::SYNCHRONOUS;
         $this->batchSize = $writeOptions["batchSize"] ??  self::DEFAULT_BATCH_SIZE;
-        $this->flushInterval = $writeOptions["flushInterval"] ??  self::DEFAULT_FLUSH_INTERVAL;
         $this->retryInterval = $writeOptions["retryInterval"] ?? self::DEFAULT_RETRY_INTERVAL;
         $this->maxRetries = $writeOptions["maxRetries"] ?? self::DEFAULT_MAX_RETRIES;
         $this->maxRetryDelay = $writeOptions["maxRetryDelay"] ?? self::DEFAULT_MAX_RETRY_DELAY;

--- a/tests/WriteApiBatchingTest.php
+++ b/tests/WriteApiBatchingTest.php
@@ -20,7 +20,7 @@ class WriteApiBatchingTest extends BasicTest
 {
     protected function getWriteOptions(): ?array
     {
-        return array('writeType' => 2, 'batchSize' => 2, 'flushInterval' => 5000);
+        return array('writeType' => 2, 'batchSize' => 2);
     }
 
     public function testBatchSize()

--- a/tests/WriteApiIntegrationTest.php
+++ b/tests/WriteApiIntegrationTest.php
@@ -67,7 +67,7 @@ class WriteApiIntegrationTest extends TestCase
     public function testBatchingWrite()
     {
         $writeApi = $this->client->createWriteApi(
-            ["writeType"=>WriteType::BATCHING, 'batchSize'=>3, "flushInterval" =>1000]);
+            ["writeType"=>WriteType::BATCHING, 'batchSize'=>3]);
 
         $data = ['name' => 'cpu',
             'tags' => ['host' => 'server_nl', 'region' => 'us'],


### PR DESCRIPTION
Closes 

- [ ] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `make test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
