### PR TITLE
feat: retry strategy for connection errors #34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 1. [#32](https://github.com/influxdata/influxdb-client-php/pull/32): Added retryInterval, maxRetries and maxRetryDelay to WriteOptions in WriteApi
 1. [#36](https://github.com/influxdata/influxdb-client-php/pull/35): Added exponentialBase to WriteApi
+1. [#34](https://github.com/influxdata/influxdb-client-php/issues/34): Retry strategy now work also for connection errors
 1. [#17](https://github.com/influxdata/influxdb-client-php/issues/17): Implemented default tags
 
 ### Bug Fixes

--- a/src/InfluxDB2/ApiException.php
+++ b/src/InfluxDB2/ApiException.php
@@ -28,6 +28,7 @@
 
 namespace InfluxDB2;
 
+use GuzzleHttp\Exception\ConnectException;
 use RuntimeException;
 
 /**
@@ -65,14 +66,15 @@ class ApiException extends RuntimeException
     /**
      * Constructor
      *
-     * @param string        $message         Error message
-     * @param int           $code            HTTP status code
+     * @param ConnectException|null $previous The previous throwable used for the exception chaining.
+     * @param string $message Error message
+     * @param int $code HTTP status code
      * @param string[]|null $responseHeaders HTTP response header
-     * @param mixed         $responseBody    HTTP decoded body of the server response either as \stdClass or string
+     * @param mixed $responseBody HTTP decoded body of the server response either as \stdClass or string
      */
-    public function __construct($message = "", $code = 0, $responseHeaders = [], $responseBody = null)
+    public function __construct($previous = null, $message = "", $code = 0, $responseHeaders = [], $responseBody = null)
     {
-        parent::__construct($message, $code);
+        parent::__construct($message, $code, $previous);
         $this->responseHeaders = $responseHeaders;
         $this->responseBody = $responseBody;
     }

--- a/src/InfluxDB2/DefaultApi.php
+++ b/src/InfluxDB2/DefaultApi.php
@@ -87,6 +87,7 @@ class DefaultApi
 
         } catch (RequestException $e) {
             throw new ApiException(
+                $e,
                 "[{$e->getCode()}] {$e->getMessage()}",
                 $e->getCode(),
                 $e->getResponse() ? $e->getResponse()->getHeaders() : null,

--- a/src/InfluxDB2/DefaultApi.php
+++ b/src/InfluxDB2/DefaultApi.php
@@ -73,6 +73,7 @@ class DefaultApi
 
             if ($statusCode < 200 || $statusCode > 299) {
                 throw new ApiException(
+                    null,
                     sprintf(
                         '[%d] Error connecting to the API (%s)',
                         $statusCode,

--- a/src/InfluxDB2/PointSettings.php
+++ b/src/InfluxDB2/PointSettings.php
@@ -1,0 +1,35 @@
+<?php
+
+
+namespace InfluxDB2;
+
+
+class PointSettings
+{
+    private $defaultTags;
+
+    public function __construct(array $defaultTags = null)
+    {
+        $this->defaultTags = is_null($defaultTags) ? [] : $defaultTags;
+    }
+
+    public function addDefaultTag(string $key, string $expression)
+    {
+        $this->defaultTags[$key] = $expression;
+    }
+
+    public static function getValue(string $value): string
+    {
+        if (substr( $value, 0, 6 ) === '${env.')
+        {
+            return getenv(substr( $value, 6, strlen($value) - 7));
+        }
+
+        return $value;
+    }
+
+    public function getDefaultTags()
+    {
+        return $this->defaultTags;
+    }
+}

--- a/tests/WriteApiTest.php
+++ b/tests/WriteApiTest.php
@@ -17,9 +17,9 @@ class WriteApiTest extends BasicTest
     private const ID_TAG = "132-987-655";
     private const CUSTOMER_TAG = "California Miner";
 
-    public function setUp()
+    public function setUp($url = "http://localhost:9999")
     {
-        parent::setUp();
+        parent::setUp($url);
 
         putenv("data_center=LA");
     }


### PR DESCRIPTION
Closes #34 

## Proposed Changes

Client now retries requests also when there is connection error.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `make test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
