### PR TITLE
chore: influxdb:2.0.0-rc is used as stable build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
         default: &default-php-image "circleci/php:7.3"
       influxdb-image:
         type: string
-        default: &default-influxdb-image "influxdb:2.0.0-beta"
+        default: &default-influxdb-image "influxdb:2.0.0-rc"
     docker:
       - image: << parameters.php-image >>
       - image: &influx-image quay.io/influxdb/<< parameters.influxdb-image >>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     network_mode: host
 
   influxdb_v2:
-    image: quay.io/influxdb/influxdb:2.0.0-beta
+    image: quay.io/influxdb/influxdb:2.0.0-rc
     ports:
       - "8086:8086"
     command: influxd --reporting-disabled


### PR DESCRIPTION
## Proposed Changes

- changed base image to `influxdb:2.0.0-rc`

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] `make test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
