### PR TITLE
feat: improved logging message for retries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage.xml
 /scripts/.m2/
 /generated/
 /*.iml
+log_test.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 1. [#44](https://github.com/influxdata/influxdb-client-php/pull/44): Added generated APIs from swagger for InfluxDB 2.0 management, buckets, organizations, authorizations...
+1. [#45](https://github.com/influxdata/influxdb-client-php/pull/45): Improved logging message for retries
 
 ## 1.7.0 [2020-10-02]
 

--- a/src/InfluxDB2/Client.php
+++ b/src/InfluxDB2/Client.php
@@ -2,9 +2,9 @@
 
 namespace InfluxDB2;
 
-use RuntimeException;
 use InfluxDB2\Model\HealthCheck;
 use ReflectionClass;
+use RuntimeException;
 
 /**
  *  @template T
@@ -30,6 +30,7 @@ class Client
      *          "precision" => WritePrecision::NS,
      *          "org" => "my-org",
      *          "debug" => false,
+     *          "logFile" => "php://output",
      *          "tags" => ['id' => '1234',
      *              'hostname' => '${env.Hostname}']
      *          ]);

--- a/src/InfluxDB2/DefaultApi.php
+++ b/src/InfluxDB2/DefaultApi.php
@@ -116,5 +116,19 @@ class DefaultApi
             throw new InvalidArgumentException("The '${key}' should be defined as argument or default option: {$options}");
         }
     }
+
+    /**
+     * Log message with specified severity to log file defined by: 'options['logFile']'.
+     *
+     * @param string $level log severity
+     * @param string $message log message
+     */
+    function log(string $level, string $message): void
+    {
+        $logFile = isset($this->options['logFile']) ? $this->options['logFile'] : "php://output";
+        $logDate = date('H:i:s d-M-Y');
+
+        file_put_contents($logFile, "[{$logDate}]: [{$level}] - {$message}", FILE_APPEND);
+    }
 }
 

--- a/src/InfluxDB2/WriteApi.php
+++ b/src/InfluxDB2/WriteApi.php
@@ -178,6 +178,13 @@ class WriteApi extends DefaultApi
                 $timeout = min($retryInterval, $this->writeOptions->maxRetryDelay) * 1000.0;
             }
 
+            $timeoutInSec = $timeout / 1000000.0;
+            $error = $e->getResponseBody();
+            $error = isset($error) ? $error : $e->getMessage();
+
+            $message = "The retriable error occurred during writing of data. Reason: '{$error}'. Retry in: {$timeoutInSec}s.";
+            $this->log("WARNING", $message);
+
             usleep($timeout);
 
             $this->writeRawInternal($data, $queryParams, $attempts + 1,

--- a/tests/BasicTest.php
+++ b/tests/BasicTest.php
@@ -31,16 +31,18 @@ abstract class BasicTest extends TestCase
 
     /**
      * @before
-     * @param $url
+     * @param string $url
+     * @param string $logFile default log file
      */
-    public function setUp($url = "http://localhost:8086")
+    public function setUp($url = "http://localhost:8086", $logFile = "php://output")
     {
         $this->client = new Client([
             "url" => $url,
             "token" => "my-token",
             "bucket" => "my-bucket",
             "precision" => WritePrecision::NS,
-            "org" => "my-org"
+            "org" => "my-org",
+            "logFile" => $logFile
         ]);
 
         $this->writeApi = $this->client->createWriteApi($this->getWriteOptions());


### PR DESCRIPTION
## Proposed Changes

The message looks like:

 _The retriable error occurred during writing of data. Reason: 'org 04014de4ed590000 has exceeded limited_write plan limit'. Retry in 5s._

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `make test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
