### PR TITLE
fix: CircleCI build with new XDEBUG v3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,17 +55,11 @@ commands:
       - run:
           name: Run tests
           command: |
-            if [[ "<< parameters.php-image >>" == "circleci/php:7.4" ]]; then
-              vendor/bin/phpunit tests --coverage-clover=coverage.xml
-            else
-              vendor/bin/phpunit tests
-            fi
+            export XDEBUG_MODE=coverage
+            vendor/bin/phpunit tests --coverage-clover=coverage.xml
       - run:
           name: "Collecting coverage reports"
-          command: |
-            if [[ "<< parameters.php-image >>" == "circleci/php:7.4" ]]; then
-              bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
-            fi
+          command: bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
       - save_cache:
           name: Saving Cache
           key: composer-v1-{{ checksum "composer.json" }}-<< parameters.php-image >>


### PR DESCRIPTION
## Proposed Changes

XDEBUG should use coverage mode to avoid - "Use of undefined constant XDEBUG_CC_UNUSED"

![Screenshot 2020-11-30 at 08 32 22](https://user-images.githubusercontent.com/455137/100580648-9fcfe180-32e6-11eb-8bf7-456f0a6788c7.png)


https://app.circleci.com/pipelines/github/influxdata/influxdb-client-php/491/workflows/5827038f-74a1-4411-abec-bf80304b554b/jobs/1364

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [x] Rebased/mergeable
- [ ] A test has been added if appropriate
- [x] `make test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
