### PR TITLE
feat: added possibility to disable verification of SSL certificate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 1. [#53](https://github.com/influxdata/influxdb-client-php/pull/53): Ability to write via UDP protocol
+1. [#57](https://github.com/influxdata/influxdb-client-php/pull/57): Added possibility to disable verification of SSL certificate
 
 ## 1.9.0 [2020-12-04]
 

--- a/README.md
+++ b/README.md
@@ -50,13 +50,9 @@ $client = new InfluxDB2\Client([
 | bucket | Default destination bucket for writes | String | none |
 | org | Default organization bucket for writes | String | none |
 | precision | Default precision for the unix timestamps within the body line-protocol | String | none |
+| verifySSL | Turn on/off SSL certificate verification. Set to `false` to disable certificate verification. | bool | true |
 
 
-<!--- TODO
-| open_timeout | Number of seconds to wait for the connection to open | Integer | 10 |
-| write_timeout | Number of seconds to wait for one block of data to be written | Integer | 10 |
-| read_timeout | Number of seconds to wait for one block of data to be read | Integer | 10 |
--->
 
 ### Queries
 

--- a/src/InfluxDB2/DefaultApi.php
+++ b/src/InfluxDB2/DefaultApi.php
@@ -24,8 +24,9 @@ class DefaultApi
         $this->options = $options;
 
         $this->http = new Client([
-            'base_uri' => $this->options["url"],
+            'base_uri' => $this->options['url'],
             'timeout' => self::DEFAULT_TIMEOUT,
+            'verify' => $this->options['verifySSL'] ?? true,
             'headers' => [
                 'Authorization' => "Token {$this->options['token']}"
             ],

--- a/tests/DefaultApiTest.php
+++ b/tests/DefaultApiTest.php
@@ -4,6 +4,8 @@ namespace InfluxDB2Test;
 
 use GuzzleHttp\Psr7\Response;
 use InfluxDB2\ApiException;
+use InfluxDB2\Client;
+use InfluxDB2\Model\WritePrecision;
 use InvalidArgumentException;
 
 require_once('BasicTest.php');
@@ -69,5 +71,31 @@ class DefaultApiTest extends BasicTest
         $this->expectException(InvalidArgumentException::class);
 
         $this->writeApi->write('h2o,location=west value=33i 15');
+    }
+
+    public function testDefaultVerifySSL()
+    {
+        $config = $this->writeApi->http->getConfig();
+
+        $this->assertEquals(true, $config['verify']);
+    }
+
+    public function testConfigureVerifySSL()
+    {
+        $client = new Client([
+            "url" => "http://localhost:8086",
+            "token" => "my-token",
+            "bucket" => "my-bucket",
+            "precision" => WritePrecision::NS,
+            "org" => "my-org",
+            "logFile" => "php://output",
+            "verifySSL" => false
+        ]);
+
+        $config = $client->createQueryApi()->http->getConfig();
+
+        $this->assertEquals(false, $config['verify']);
+
+        $client->close();
     }
 }


### PR DESCRIPTION
Closes #55

## Proposed Changes

Added possibility to disable verification of SSL certificate. https://docs.guzzlephp.org/en/stable/request-options.html#verify-option

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `make test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
