### PR TITLE
chore(ci): update default docker image to v2.0.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
         default: &default-php-image "circleci/php:7.4"
       influxdb-image:
         type: string
-        default: &default-influxdb-image "influxdb:v2.0.2"
+        default: &default-influxdb-image "influxdb:v2.0.3"
       guzzle-version:
         type: string
         default: "6.5.3"
@@ -122,7 +122,7 @@ workflows:
           guzzle-version: "7.0.1"
       - tests-php:
           name: php-7.4-nightly
-          influxdb-image: "influx:nightly"
+          influxdb-image: "influxdb2:nightly"
       - tests-php:
           name: php-7.3
           php-image: "circleci/php:7.3"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 1. [#53](https://github.com/influxdata/influxdb-client-php/pull/53): Ability to write via UDP protocol
 1. [#57](https://github.com/influxdata/influxdb-client-php/pull/57): Added possibility to disable verification of SSL certificate
 
+### CI
+1. [#58](https://github.com/influxdata/influxdb-client-php/pull/58): Updated default docker image to v2.0.3
+
 ## 1.9.0 [2020-12-04]
 
 ### Features

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     network_mode: host
 
   influxdb_v2:
-    image: quay.io/influxdb/influxdb:v2.0.2
+    image: quay.io/influxdb/influxdb:v2.0.3
     ports:
       - "8086:8086"
     command: influxd --reporting-disabled


### PR DESCRIPTION
## Proposed Changes

- Updated default docker image to `v2.0.3`
- Updated nightly docker image to `influxdb2:nightly`

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `make test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
