### PR TITLE
chore(ci): use latest tag for InfluxDB 2, use correct image for InfluxDB 2 nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,13 +79,13 @@ jobs:
         default: &default-php-image "circleci/php:7.4"
       influxdb-image:
         type: string
-        default: &default-influxdb-image "influxdb:v2.0.4"
+        default: &default-influxdb-image "influxdb:latest"
       guzzle-version:
         type: string
         default: "6.5.3"
     docker:
       - image: << parameters.php-image >>
-      - image: &influx-image quay.io/influxdb/<< parameters.influxdb-image >>
+      - image: &influx-image << parameters.influxdb-image >>
         environment:
           INFLUXD_HTTP_BIND_ADDRESS: :8086
     steps:
@@ -134,7 +134,7 @@ workflows:
           guzzle-version: "7.0.1"
       - tests-php:
           name: php-7.4-nightly
-          influxdb-image: "influxdb2:nightly"
+          influxdb-image: "quay.io/influxdb/influxdb:nightly"
       - tests-php:
           name: php-7.3
           php-image: "circleci/php:7.3"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 ### Documentation
 1. [#65](https://github.com/influxdata/influxdb-client-php/pull/65): Documentation for the client is located at GitHub: https://influxdata.github.io/influxdb-client-php/
 
+### CI
+1. [#67](https://github.com/influxdata/influxdb-client-php/pull/67): Updated stable image to `influxdb:latest` and nightly to `quay.io/influxdb/influxdb:nightly`
+
 ## 1.10.0 [2021-01-29]
 
 ### Features

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     network_mode: host
 
   influxdb_v2:
-    image: quay.io/influxdb/influxdb:v2.0.4
+    image: influxdb:latest
     ports:
       - "8086:8086"
     command: influxd --reporting-disabled


### PR DESCRIPTION
## Proposed Changes

- use `influxdb:latest` for stable InfluxDB 2
- use `quay.io/influxdb/influxdb:nightly` for nightly InfluxDB 2

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `make test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
