### PR TITLE
feat: Allowed to change GuzzleHTTP timeout (#72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 ## 1.12.0 [unreleased]
 
 ### Features
-1. [#68](https://github.com/influxdata/influxdb-client-php/pull/68): Moved classes to their own file
+1. [#74](https://github.com/influxdata/influxdb-client-php/pull/74): Allow to change GuzzleHTTP timeout
 
 ### API
-1. [#71](https://github.com/influxdata/influxdb-client-php/pull/71): Updated swagger to the latest version
+1. [#71](https://github.com/influxdata/influxdb-client-php/pull/71): Update swagger to the latest version
 
 ## 1.11.0 [2021-03-05]
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ $client = new InfluxDB2\Client([
 | org | Default organization bucket for writes | String | none |
 | precision | Default precision for the unix timestamps within the body line-protocol | String | none |
 | verifySSL | Turn on/off SSL certificate verification. Set to `false` to disable certificate verification. | bool | true |
-
+| timeout | Describing the number of seconds to wait while trying to connect to a server. Use 0 to wait indefinitely | int | 10 |
 
 
 ### Queries

--- a/src/InfluxDB2/Client.php
+++ b/src/InfluxDB2/Client.php
@@ -32,7 +32,8 @@ class Client
      *          "debug" => false,
      *          "logFile" => "php://output",
      *          "tags" => ['id' => '1234',
-     *              'hostname' => '${env.Hostname}']
+     *              'hostname' => '${env.Hostname}'],
+     *          "timeout" => 2
      *          ]);
      *
      * @param array $options

--- a/src/InfluxDB2/DefaultApi.php
+++ b/src/InfluxDB2/DefaultApi.php
@@ -14,7 +14,12 @@ class DefaultApi
     public $options;
     /** @var Client */
     public $http;
-
+    /**
+     * Holds GuzzleHttp timeout.
+     *
+     * @var int
+     */
+    private $timeout;
     /**
      * DefaultApi constructor.
      * @param $options
@@ -22,10 +27,10 @@ class DefaultApi
     public function __construct(array $options)
     {
         $this->options = $options;
-
+        $this->timeout = $this->options['timeout'] ?? self::DEFAULT_TIMEOUT;
         $this->http = new Client([
             'base_uri' => $this->options['url'],
-            'timeout' => self::DEFAULT_TIMEOUT,
+            'timeout' => $this->timeout,
             'verify' => $this->options['verifySSL'] ?? true,
             'headers' => [
                 'Authorization' => "Token {$this->options['token']}"
@@ -41,17 +46,17 @@ class DefaultApi
      * @param bool $stream - use streaming
      * @return ResponseInterface
      */
-    public function post($payload, $uriPath, $queryParams, $timeout = self::DEFAULT_TIMEOUT, bool $stream = false): ResponseInterface
+    public function post($payload, $uriPath, $queryParams, $timeout = null, bool $stream = false): ResponseInterface
     {
         return $this->request($payload, $uriPath, $queryParams, 'POST', $timeout, $stream);
     }
 
-    public function get($payload, $uriPath, $queryParams, $timeout = self::DEFAULT_TIMEOUT): ResponseInterface
+    public function get($payload, $uriPath, $queryParams, $timeout = null): ResponseInterface
     {
         return $this->request($payload, $uriPath, $queryParams, 'GET', $timeout, false);
     }
 
-    private function request($payload, $uriPath, $queryParams, $method, $timeout = self::DEFAULT_TIMEOUT, bool $stream = false): ResponseInterface
+    private function request($payload, $uriPath, $queryParams, $method, $timeout = null, bool $stream = false): ResponseInterface
     {
         try {
             $options = [
@@ -63,7 +68,7 @@ class DefaultApi
                 'query' => $queryParams,
                 'body' => $payload,
                 'stream' => $stream,
-                'timeout' => $timeout
+                'timeout' => $timeout ?? $this->timeout
             ];
 
             // enable debug


### PR DESCRIPTION
Closes #72 

## Proposed Changes

I made it possible to change guzzleHttp timeout.
Sadly i couldn't get tests to work so I can't run them. But I did manual testing, i'm only using Client and `createWriteApi`.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [ ] A test has been added if appropriate
- [ ] `make test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
