### PR TITLE
feat: exponential random retry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ jobs:
       - checkout
       - run: |
           mkdir -p tools/php-cs-fixer
-          composer require --working-dir=tools/php-cs-fixer friendsofphp/php-cs-fixer
+          composer require --working-dir=tools/php-cs-fixer friendsofphp/php-cs-fixer:2.18.7
           tools/php-cs-fixer/vendor/bin/php-cs-fixer fix --dry-run --verbose --show-progress=estimating --using-cache=no --diff
 
 workflows:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.13.0 [unreleased]
 
+### Features
+1. [#76](https://github.com/influxdata/influxdb-client-php/pull/76): Exponential random backoff retry strategy
+
 ## 1.12.0 [2021-04-01]
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -166,8 +166,9 @@ The writes are processed in batches which are configurable by `WriteOptions`:
 | **retryInterval** | the number of milliseconds to retry unsuccessful write. The retry interval is "exponentially" used when the InfluxDB server does not specify "Retry-After" header. | 5000 |
 | **jitterInterval** | the number of milliseconds before the data is written increased by a random amount | 0 |
 | **maxRetries** | the number of max retries when write fails | 5 |
-| **maxRetryDelay** | maximum delay when retrying write in milliseconds | 180000 |
-| **exponentialBase** | the base for the exponential retry delay, the next delay is computed as `retryInterval * exponentialBase^(attempts-1)` | 5 | 
+| **maxRetryDelay** | maximum delay when retrying write in milliseconds | 125000 |
+| **maxRetryTime** | maximum total retry timeout in milliseconds | 180000 |
+| **exponentialBase** | the base for the exponential retry delay, the next delay is computed using random exponential backoff as a random value within the interval  ``retryInterval * exponentialBase^(attempts-1)`` and ``retryInterval * exponentialBase^(attempts)``. Example for ``retryInterval=5000, exponentialBase=2, maxRetryDelay=125000, total=5`` Retry delays are random distributed values within the ranges of ``[5000-10000, 10000-20000, 20000-40000, 40000-80000, 80000-125000]`` | 2 | 
 ```php
 use InfluxDB2\Client;
 use InfluxDB2\WriteType as WriteType;

--- a/src/InfluxDB2/DefaultApi.php
+++ b/src/InfluxDB2/DefaultApi.php
@@ -130,18 +130,4 @@ class DefaultApi
             throw new InvalidArgumentException("The '${key}' should be defined as argument or default option: {$options}");
         }
     }
-
-    /**
-     * Log message with specified severity to log file defined by: 'options['logFile']'.
-     *
-     * @param string $level log severity
-     * @param string $message log message
-     */
-    protected function log(string $level, string $message): void
-    {
-        $logFile = isset($this->options['logFile']) ? $this->options['logFile'] : "php://output";
-        $logDate = date('H:i:s d-M-Y');
-
-        file_put_contents($logFile, "[{$logDate}]: [{$level}] - {$message}", FILE_APPEND);
-    }
 }

--- a/src/InfluxDB2/WriteRetry.php
+++ b/src/InfluxDB2/WriteRetry.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace InfluxDB2;
+
+use GuzzleHttp\Exception\ConnectException;
+
+/**
+ * Exponential random write retry.
+ */
+class WriteRetry
+{
+    private $maxRetries;
+    private $retryInterval;
+    private $maxRetryDelay;
+    private $exponentialBase;
+    private $jitterInterval;
+    private $maxRetryTime;
+    private $retryTimout;
+    /**
+     * @var mixed|string
+     */
+    private $logFile;
+
+    /**
+     * WriteRetry constructor.
+     *
+     * @param int $maxRetries max number of retries when write fails
+     * @param int $retryInterval number of milliseconds to retry unsuccessful write,
+     *      The retry interval is used when the InfluxDB server does not specify "Retry-After" header.
+     * @param int $maxRetryDelay maximum delay when retrying write in milliseconds
+     * @param int $exponentialBase the base for the exponential retry delay, the next delay is computed using
+     *              random exponential backoff as a random value within the interval
+     *              ``retryInterval * exponentialBase^(attempts-1)`` and
+     *              ``retryInterval * exponentialBase^(attempts)``.
+     *              Example for ``retryInterval=5000, exponentialBase=2, maxRetryDelay=125000, total=5``
+     *              Retry delays are random distributed values within the ranges of
+     *              ``[5000-10000, 10000-20000, 20000-40000, 40000-80000, 80000-125000]``
+     *
+     * @param int $maxRetryTime maximum total time when retrying write in milliseconds
+     * @param int $jitterInterval the number of milliseconds before the data is written increased by a random amount
+     * @param string $logFile logfile
+     */
+    public function __construct(int $maxRetries = 5, int $retryInterval = 5000
+        , int $maxRetryDelay = 125000, int $exponentialBase = 2,
+                                int $maxRetryTime = 180000,
+                                int $jitterInterval = 0, string $logFile = "php://output")
+    {
+        $this->maxRetries = $maxRetries;
+        $this->retryInterval = $retryInterval;
+        $this->maxRetryDelay = $maxRetryDelay;
+        $this->maxRetryTime = $maxRetryTime;
+        $this->exponentialBase = $exponentialBase;
+        $this->jitterInterval = $jitterInterval;
+        $this->logFile = $logFile;
+
+        //retry timout
+        $this->retryTimout = microtime(true) * 1000 + $maxRetryTime;
+    }
+
+    /**
+     * @throws ApiException
+     */
+    public function retry($callable, $attempts = 0)
+    {
+        try {
+            return call_user_func($callable);
+        } catch (ApiException $e) {
+
+            $error = $e->getResponseBody() ?? $e->getMessage();
+
+            if (!$this->isRetryable($e)) {
+                throw $e;
+            }
+            $attempts++;
+            if ($attempts > $this->maxRetries || !$this->isRetryable($e)) {
+                $this->log("ERROR", "Maximum retry attempts reached");
+                throw $e;
+            }
+
+            // throws exception when max retry time is exceeded
+            if (microtime(true) * 1000 > $this->retryTimout) {
+                $this->log("ERROR", "Maximum retry time $this->maxRetryTime ms exceeded");
+                throw $e;
+            }
+
+            $headers = $e->getResponseHeaders();
+            if ($headers != null && array_key_exists('Retry-After', $headers)) {
+                //jitter add in microseconds
+                $jitterMicro = rand(0, $this->jitterInterval) * 1000;
+                $timeout = (int)$headers['Retry-After'][0] * 1000000.0 + $jitterMicro;
+            } else {
+                $timeout = $this->getBackoffTime($attempts) * 1000;
+            }
+
+            $timeoutInSec = $timeout / 1000000.0;
+
+            $message = "The retryable error occurred during writing of data. Reason: '$error'. Retry in: {$timeoutInSec}s.";
+            $this->log("WARNING", $message);
+            usleep($timeout);
+            $this->retry($callable, $attempts);
+        }
+    }
+
+    public function isRetryable(ApiException $e): bool
+    {
+        $code = $e->getCode();
+        if (($code == null || $code < 429) &&
+            !($e->getPrevious() instanceof ConnectException)) {
+            return false;
+        }
+        return true;
+    }
+
+    public function getBackoffTime(int $attempt)
+    {
+        $range_start = $this->retryInterval;
+        $range_stop = $this->retryInterval * $this->exponentialBase;
+
+        $i = 1;
+        while ($i < $attempt) {
+            $i += 1;
+            $range_start = $range_stop;
+            $range_stop = $range_stop * $this->exponentialBase;
+            if ($range_stop > $this->maxRetryDelay)
+                break;
+        }
+
+        if ($range_stop > $this->maxRetryDelay) {
+            $range_stop = $this->maxRetryDelay;
+        }
+        return $range_start + ($range_stop - $range_start) * (rand(0, 1000) / 1000);
+    }
+
+    private function log(string $level, string $message): void
+    {
+        $logDate = date('H:i:s d-M-Y');
+        file_put_contents($this->logFile, "[$logDate]: [$level] - $message".PHP_EOL, FILE_APPEND);
+    }
+
+}

--- a/src/InfluxDB2/WriteRetry.php
+++ b/src/InfluxDB2/WriteRetry.php
@@ -75,7 +75,7 @@ class WriteRetry
                 throw $e;
             }
             $attempts++;
-            if ($attempts > $this->maxRetries || !$this->isRetryable($e)) {
+            if ($attempts > $this->maxRetries) {
                 $this->log("ERROR", "Maximum retry attempts reached");
                 throw $e;
             }

--- a/src/InfluxDB2/WriteRetry.php
+++ b/src/InfluxDB2/WriteRetry.php
@@ -40,11 +40,15 @@ class WriteRetry
      * @param int $jitterInterval the number of milliseconds before the data is written increased by a random amount
      * @param string $logFile logfile
      */
-    public function __construct(int $maxRetries = 5, int $retryInterval = 5000
-        , int $maxRetryDelay = 125000, int $exponentialBase = 2,
-                                int $maxRetryTime = 180000,
-                                int $jitterInterval = 0, string $logFile = "php://output")
-    {
+    public function __construct(
+        int $maxRetries = 5,
+        int $retryInterval = 5000,
+        int $maxRetryDelay = 125000,
+        int $exponentialBase = 2,
+        int $maxRetryTime = 180000,
+        int $jitterInterval = 0,
+        string $logFile = "php://output"
+    ) {
         $this->maxRetries = $maxRetries;
         $this->retryInterval = $retryInterval;
         $this->maxRetryDelay = $maxRetryDelay;
@@ -65,7 +69,6 @@ class WriteRetry
         try {
             return call_user_func($callable);
         } catch (ApiException $e) {
-
             $error = $e->getResponseBody() ?? $e->getMessage();
 
             if (!$this->isRetryable($e)) {
@@ -121,8 +124,9 @@ class WriteRetry
             $i += 1;
             $range_start = $range_stop;
             $range_stop = $range_stop * $this->exponentialBase;
-            if ($range_stop > $this->maxRetryDelay)
+            if ($range_stop > $this->maxRetryDelay) {
                 break;
+            }
         }
 
         if ($range_stop > $this->maxRetryDelay) {
@@ -136,5 +140,4 @@ class WriteRetry
         $logDate = date('H:i:s d-M-Y');
         file_put_contents($this->logFile, "[$logDate]: [$level] - $message".PHP_EOL, FILE_APPEND);
     }
-
 }

--- a/tests/WriteApiBatchingTest.php
+++ b/tests/WriteApiBatchingTest.php
@@ -32,7 +32,7 @@ class WriteApiBatchingTest extends BasicTest
         $this->writeApi->write('h2o_feet,location=coyote_creek level\\ water_level=3.0 3');
         $this->writeApi->write('h2o_feet,location=coyote_creek level\\ water_level=4.0 4');
 
-        $this->assertEquals(2, count($this->container));
+        $this->assertCount(2, $this->container);
 
         $result1 = "h2o_feet,location=coyote_creek level\\ water_level=1.0 1\n"
             . "h2o_feet,location=coyote_creek level\\ water_level=2.0 2";
@@ -93,7 +93,7 @@ class WriteApiBatchingTest extends BasicTest
             'my-org-a'
         );
 
-        $this->assertEquals(5, count($this->container));
+        $this->assertCount(5, $this->container);
 
         $request = $this->container[0]['request'];
 
@@ -176,7 +176,7 @@ class WriteApiBatchingTest extends BasicTest
         $this->writeApi->write('h2o_feet,location=coyote_creek water_level=1.0 1');
         $this->writeApi->write('h2o_feet,location=coyote_creek water_level=2.0 2');
 
-        $this->assertEquals(2, count($this->container));
+        $this->assertCount(2, $this->container);
         $request = $this->mockHandler->getLastRequest();
 
         $this->assertEquals(
@@ -202,7 +202,7 @@ class WriteApiBatchingTest extends BasicTest
         $this->writeApi->write('h2o_feet,location=coyote_creek water_level=1.0 1');
         $this->writeApi->write('h2o_feet,location=coyote_creek water_level=2.0 2');
 
-        $this->assertEquals(2, count($this->container));
+        $this->assertCount(2, $this->container);
         $request = $this->mockHandler->getLastRequest();
 
         $this->assertEquals(
@@ -231,7 +231,7 @@ class WriteApiBatchingTest extends BasicTest
         $this->writeApi->write('h2o_feet,location=coyote_creek water_level=1.0 1');
         $this->writeApi->write('h2o_feet,location=coyote_creek water_level=2.0 2');
 
-        $this->assertEquals(3, count($this->container));
+        $this->assertCount(3, $this->container);
     }
 
     public function testRetryCount()
@@ -265,7 +265,7 @@ class WriteApiBatchingTest extends BasicTest
             $this->assertEquals(429, $e->getCode());
         }
 
-        $this->assertEquals(4, count($this->container));
+        $this->assertCount(4, $this->container);
 
         $count = $this->mockHandler->count();
         $this->assertEquals(1, $count);
@@ -291,7 +291,7 @@ class WriteApiBatchingTest extends BasicTest
         $this->writeApi->write('h2o_feet,location=coyote_creek water_level=1.0 1');
         $this->writeApi->write('h2o_feet,location=coyote_creek water_level=2.0 2');
 
-        $this->assertEquals(3, count($this->container));
+        $this->assertCount(3, $this->container);
     }
 
     public function testJitterInterval()
@@ -312,7 +312,7 @@ class WriteApiBatchingTest extends BasicTest
 
         $this->assertTrue($time > 0 && $time <= 2);
 
-        $this->assertEquals(1, count($this->container));
+        $this->assertCount(1, $this->container);
 
         $result1 = "h2o_feet,location=coyote_creek level\\ water_level=1.0 1\n"
             . "h2o_feet,location=coyote_creek level\\ water_level=2.0 2";
@@ -341,9 +341,9 @@ class WriteApiBatchingTest extends BasicTest
         $this->writeApi->write('h2o_feet,location=coyote_creek water_level=1.0 1');
         $this->writeApi->write('h2o_feet,location=coyote_creek water_level=2.0 2');
 
-        $this->assertEquals(2, count($this->container));
+        $this->assertCount(2, $this->container);
 
         $message = file_get_contents("log_test.txt");
-        $this->assertStringContainsString("The retriable error occurred during writing of data. Reason: 'org 04014de4ed590000 has exceeded limited_write plan limit'. Retry in: 3s.", $message);
+        $this->assertStringContainsString("The retryable error occurred during writing of data. Reason: 'org 04014de4ed590000 has exceeded limited_write plan limit'. Retry in: 3s.", $message);
     }
 }

--- a/tests/WriteApiTest.php
+++ b/tests/WriteApiTest.php
@@ -326,8 +326,8 @@ class WriteApiTest extends BasicTest
     }
 
 
-    public function testRetryBackoffTime() {
-
+    public function testRetryBackoffTime()
+    {
         $retry = new WriteRetry();
 
         $backoff = $retry->getBackoffTime(1);
@@ -355,8 +355,9 @@ class WriteApiTest extends BasicTest
         $this->assertLessThan(125000, $backoff);
     }
 
-    public function testConnectExceptionRetry () {
-       $client = new Client([
+    public function testConnectExceptionRetry()
+    {
+        $client = new Client([
             "url" => "http://nonexistenthost:8086/",
             "token" => "my-token",
             "bucket" => "my-bucket",
@@ -365,7 +366,7 @@ class WriteApiTest extends BasicTest
             "logFile" => "php://output"
         ]);
 
-        $writeApi = $client->createWriteApi( ["retryInterval" => 100] );
+        $writeApi = $client->createWriteApi(["retryInterval" => 100]);
         $point = Point::measurement('h2o')
             ->addTag('location', 'europe')
             ->addField('level', 2);
@@ -379,6 +380,5 @@ class WriteApiTest extends BasicTest
             $this->assertEquals(ConnectException::class, get_class($e->getPrevious()));
             throw $e;
         }
-
     }
 }

--- a/tests/WriteApiTest.php
+++ b/tests/WriteApiTest.php
@@ -2,9 +2,14 @@
 
 namespace InfluxDB2Test;
 
+use Exception;
+use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Psr7\Response;
 use InfluxDB2\ApiException;
+use InfluxDB2\Client;
+use InfluxDB2\Model\WritePrecision;
 use InfluxDB2\Point;
+use InfluxDB2\WriteRetry;
 
 require_once('BasicTest.php');
 
@@ -142,7 +147,7 @@ class WriteApiTest extends BasicTest
             $this->assertEquals(400, $e->getCode());
             $this->assertEquals('invalid', implode($e->getResponseHeaders()['X-Platform-Error-Code']));
             $this->assertEquals($errorBody, strval($e->getResponseBody()));
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $this->fail();
         }
     }
@@ -282,15 +287,98 @@ class WriteApiTest extends BasicTest
             ->addTag('location', 'europe')
             ->addField('level', 2);
 
+        $this->expectExceptionCode(429);
+        $this->expectException(ApiException::class);
+        $this->writeApi->write($point);
+
+        $this->assertCount(4, $this->container);
+        $this->assertCount(1, $this->mockHandler);
+    }
+
+    public function testRetryMaxTime()
+    {
+        $this->mockHandler->append(
+        // regular call
+            new Response(429),
+            // retry
+            new Response(429),
+            // retry
+            new Response(200)
+        );
+
+        $this->writeApi->writeOptions->retryInterval = 1000;
+        $this->writeApi->writeOptions->maxRetries = 3;
+        $this->writeApi->writeOptions->maxRetryDelay = 15000;
+        $this->writeApi->writeOptions->exponentialBase = 2;
+        $this->writeApi->writeOptions->maxRetryTime = 300;
+
+        $point = Point::measurement('h2o')
+            ->addTag('location', 'europe')
+            ->addField('level', 2);
+
+        $this->expectException(ApiException::class);
+        $this->expectExceptionCode(429);
+
+        $this->writeApi->write($point);
+
+        $this->assertCount(2, $this->container);
+        $this->assertCount(1, $this->mockHandler);
+    }
+
+
+    public function testRetryBackoffTime() {
+
+        $retry = new WriteRetry();
+
+        $backoff = $retry->getBackoffTime(1);
+        $this->assertGreaterThan(5000, $backoff);
+        $this->assertLessThan(10000, $backoff);
+
+        $backoff = $retry->getBackoffTime(2);
+        $this->assertGreaterThan(10000, $backoff);
+        $this->assertLessThan(20000, $backoff);
+
+        $backoff = $retry->getBackoffTime(3);
+        $this->assertGreaterThan(20000, $backoff);
+        $this->assertLessThan(40000, $backoff);
+
+        $backoff = $retry->getBackoffTime(4);
+        $this->assertGreaterThan(40000, $backoff);
+        $this->assertLessThan(80000, $backoff);
+
+        $backoff = $retry->getBackoffTime(5);
+        $this->assertGreaterThan(80000, $backoff);
+        $this->assertLessThan(125000, $backoff);
+
+        $backoff = $retry->getBackoffTime(6);
+        $this->assertGreaterThan(80000, $backoff);
+        $this->assertLessThan(125000, $backoff);
+    }
+
+    public function testConnectExceptionRetry () {
+       $client = new Client([
+            "url" => "http://nonexistenthost:8086/",
+            "token" => "my-token",
+            "bucket" => "my-bucket",
+            "precision" => WritePrecision::NS,
+            "org" => "my-org",
+            "logFile" => "php://output"
+        ]);
+
+        $writeApi = $client->createWriteApi( ["retryInterval" => 100] );
+        $point = Point::measurement('h2o')
+            ->addTag('location', 'europe')
+            ->addField('level', 2);
+
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessage("Could not resolve host: nonexistenthost");
+
         try {
-            $this->writeApi->write($point);
+            $writeApi->write($point);
         } catch (ApiException $e) {
-            $this->assertEquals(429, $e->getCode());
+            $this->assertEquals(ConnectException::class, get_class($e->getPrevious()));
+            throw $e;
         }
 
-        $this->assertEquals(4, count($this->container));
-
-        $count = $this->mockHandler->count();
-        $this->assertEquals(1, $count);
     }
 }


### PR DESCRIPTION
## Proposed Changes

Improves exponential random retry strategy in write api like in python client https://github.com/influxdata/influxdb-client-python/pull/225

Delay is computed using random exponential backoff as a random value within the interval  ``retryInterval * exponentialBase^(attempts-1)`` and ``retryInterval * exponentialBase^(attempts)``. 

Example for ``retryInterval=5_000, exponentialBase=2, maxRetryDelay=125_000, total=5``

Retry delays are random distributed values within the ranges of ``[5_000-10_000, 10_000-20_000, 20_000-40_000, 40_000-80_000, 80_000-125_000]``

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [ ] A test has been added if appropriate
- [x] `make test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
