### PR TITLE
fix: serialization tags which are not a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.14.0 [unreleased]
 
+### Bug Fixes
+1. [#81](https://github.com/influxdata/influxdb-client-php/pull/81): Compatibility with PHP 7.1 and 7.2
+
 ## 1.13.0 [2021-06-04]
 
 ### Features

--- a/src/InfluxDB2/Point.php
+++ b/src/InfluxDB2/Point.php
@@ -260,6 +260,6 @@ class Point
 
     private function isNullOrEmptyString($str)
     {
-        return (!isset($str) || trim($str) === '');
+        return (!is_string($str) || trim($str) === '');
     }
 }

--- a/tests/PointTest.php
+++ b/tests/PointTest.php
@@ -263,7 +263,8 @@ class PointTest extends TestCase
         $this->assertNull($pointArray);
     }
 
-    public function testTagNotString() {
+    public function testTagNotString()
+    {
         $point = Point::measurement('h2o')
             ->addTag('location', 'europe')
             ->addTag('tag_not_string', [])

--- a/tests/PointTest.php
+++ b/tests/PointTest.php
@@ -262,4 +262,14 @@ class PointTest extends TestCase
 
         $this->assertNull($pointArray);
     }
+
+    public function testTagNotString() {
+        $point = Point::measurement('h2o')
+            ->addTag('location', 'europe')
+            ->addTag('tag_not_string', [])
+            ->addTag('tag_not_null', null)
+            ->addField('level', 2);
+
+        $this->assertEquals('h2o,location=europe level=2i', $point->toLineProtocol());
+    }
 }


### PR DESCRIPTION
Closes #80

## Proposed Changes

Correct serialisation to LineProtocol for tags which are not a `string`.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `make test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
