### PR TITLE
fix: stick on 1.X version of guzzlehttp/psr7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ commands:
       - restore_cache:
           name: Restoring Composer Cache
           keys:
-              - composer-v1-{{ checksum "composer.json" }}-<< parameters.php-image >>-<< parameters.guzzle-version >>
+              # - composer-v1-{{ checksum "composer.json" }}-<< parameters.php-image >>-<< parameters.guzzle-version >>
               - composer-v1-{{ checksum "composer.json" }}-<< parameters.php-image >>
               - composer-v1-{{ checksum "composer.json" }}
               - composer-v1-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ commands:
       - restore_cache:
           name: Restoring Composer Cache
           keys:
-              # - composer-v1-{{ checksum "composer.json" }}-<< parameters.php-image >>-<< parameters.guzzle-version >>
+              - composer-v1-{{ checksum "composer.json" }}-<< parameters.php-image >>-<< parameters.guzzle-version >>
               - composer-v1-{{ checksum "composer.json" }}-<< parameters.php-image >>
               - composer-v1-{{ checksum "composer.json" }}
               - composer-v1-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,11 +141,11 @@ workflows:
       - tests-php:
           name: php-7.2
           php-image: "circleci/php:7.2"
-          guzzle-version: "6^"
+          guzzle-version: "^6"
       - tests-php:
           name: php-7.1
           php-image: "circleci/php:7.1"
-          guzzle-version: "6^"
+          guzzle-version: "^6"
       - tests-windows:
           name: php-windows
       - check-code-style

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ jobs:
         default: &default-influxdb-image "influxdb:latest"
       guzzle-version:
         type: string
-        default: "6.5.3"
+        default: "^7"
     docker:
       - image: << parameters.php-image >>
       - image: &influx-image << parameters.influxdb-image >>
@@ -141,9 +141,11 @@ workflows:
       - tests-php:
           name: php-7.2
           php-image: "circleci/php:7.2"
+          guzzle-version: "6^"
       - tests-php:
           name: php-7.1
           php-image: "circleci/php:7.1"
+          guzzle-version: "6^"
       - tests-windows:
           name: php-windows
       - check-code-style

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     "ext-curl": "*",
     "ext-json": "*",
     "ext-mbstring": "*",
-    "guzzlehttp/guzzle": "^6.2|^7.0.1"
+    "guzzlehttp/guzzle": "^6.2|^7.0.1",
+    "guzzlehttp/psr7": "^1.7"
   },
   "require-dev": {
     "phpunit/phpunit": "^7.4|^9.1",


### PR DESCRIPTION
## Proposed Changes

Generated client sources are not compatible with the new version of guzzlehttp/psr7 2.0 

It also breaks circle ci builds, we need to stick on 1.X for now.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [ ] Rebased/mergeable
- [ ] A test has been added if appropriate
- [ ] `make test` completes successfully
- [ ] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
