### PR TITLE
chore(ci): switch to next-gen CircleCI's convenience images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,10 +43,10 @@ commands:
       - restore_cache:
           name: Restoring Composer Cache
           keys:
-              - composer-v1-{{ checksum "composer.json" }}-<< parameters.php-image >>-<< parameters.guzzle-version >>
-              - composer-v1-{{ checksum "composer.json" }}-<< parameters.php-image >>
-              - composer-v1-{{ checksum "composer.json" }}
-              - composer-v1-
+              - composer-v2-{{ checksum "composer.json" }}-<< parameters.php-image >>-<< parameters.guzzle-version >>
+              - composer-v2-{{ checksum "composer.json" }}-<< parameters.php-image >>
+              - composer-v2-{{ checksum "composer.json" }}
+              - composer-v2-
       - run:
           name: Install dependencies
           command: |
@@ -62,7 +62,7 @@ commands:
           command: bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
       - save_cache:
           name: Saving Cache
-          key: composer-v1-{{ checksum "composer.json" }}-<< parameters.php-image >>
+          key: composer-v2-{{ checksum "composer.json" }}-<< parameters.php-image >>
           paths:
             - vendor
           when: always
@@ -76,7 +76,7 @@ jobs:
     parameters:
       php-image:
         type: string
-        default: &default-php-image "circleci/php:7.4"
+        default: &default-php-image "cimg/php:7.4"
       influxdb-image:
         type: string
         default: &default-influxdb-image "influxdb:latest"
@@ -128,7 +128,7 @@ workflows:
           name: php-7.4
       - tests-php:
           name: php-8.0
-          php-image: "circleci/php:8.0"
+          php-image: "cimg/php:8.0"
       - tests-php:
           name: php-7.4-guzzle-7
           guzzle-version: "7.0.1"
@@ -137,14 +137,14 @@ workflows:
           influxdb-image: "quay.io/influxdb/influxdb:nightly"
       - tests-php:
           name: php-7.3
-          php-image: "circleci/php:7.3"
+          php-image: "cimg/php:7.3"
       - tests-php:
           name: php-7.2
-          php-image: "circleci/php:7.2"
+          php-image: "cimg/php:7.2"
           guzzle-version: "^6"
       - tests-php:
           name: php-7.1
-          php-image: "circleci/php:7.1"
+          php-image: "cimg/php:7.1"
           guzzle-version: "^6"
       - tests-windows:
           name: php-windows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,10 +43,10 @@ commands:
       - restore_cache:
           name: Restoring Composer Cache
           keys:
-              - composer-v2-{{ checksum "composer.json" }}-<< parameters.php-image >>-<< parameters.guzzle-version >>
-              - composer-v2-{{ checksum "composer.json" }}-<< parameters.php-image >>
-              - composer-v2-{{ checksum "composer.json" }}
-              - composer-v2-
+              - composer-v3-{{ checksum "composer.json" }}-<< parameters.php-image >>-<< parameters.guzzle-version >>
+              - composer-v3-{{ checksum "composer.json" }}-<< parameters.php-image >>
+              - composer-v3-{{ checksum "composer.json" }}
+              - composer-v3-
       - run:
           name: Install dependencies
           command: |
@@ -62,7 +62,7 @@ commands:
           command: bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
       - save_cache:
           name: Saving Cache
-          key: composer-v2-{{ checksum "composer.json" }}-<< parameters.php-image >>
+          key: composer-v3-{{ checksum "composer.json" }}-<< parameters.php-image >>
           paths:
             - vendor
           when: always
@@ -144,7 +144,7 @@ workflows:
           guzzle-version: "^6"
       - tests-php:
           name: php-7.1
-          php-image: "cimg/php:7.1"
+          php-image: "circleci/php:7.1"
           guzzle-version: "^6"
       - tests-windows:
           name: php-windows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Features
 1. [#86](https://github.com/influxdata/influxdb-client-php/pull/86): Add configuration option for `proxy` and `redirects`
 
+### CI
+1. [#90](https://github.com/influxdata/influxdb-client-php/pull/90): Switch to next-gen CircleCI's convenience images
+
 ## 2.1.0 [2021-08-20]
 
 ### Bug Fixes


### PR DESCRIPTION
## Proposed Changes

The current images are deprecated and no longer supported:
- https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034?mkt_tok=NDg1LVpNSC02MjYAAAF_aZ4aQBMMtwIJatxoGz4de_IMPoNZJOUAhbHY2j7KD_4fR38oMpf0qFjUBd15_QNaVKiHbjM5WE0emhPAvcNcagGm1rnILLJptARAtBWPhtQ
- https://circleci.com/blog/announcing-our-next-generation-convenience-images-smaller-faster-more-deterministic/

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `make test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
