### PR TITLE
feat: add configuration option for ipv4 or ipv6, defaults to ipv4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Features
 1. [#86](https://github.com/influxdata/influxdb-client-php/pull/86): Add configuration option for `proxy` and `redirects`
-2. [#92](https://github.com/influxdata/influxdb-client-php/pull/92): Add configuration option for `ipVersion`
+2. [#92](https://github.com/influxdata/influxdb-client-php/pull/92): Add configuration option for `ipVersion` [UDP Writer]
 
 ### CI
 1. [#90](https://github.com/influxdata/influxdb-client-php/pull/90): Switch to next-gen CircleCI's convenience images

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 1. [#86](https://github.com/influxdata/influxdb-client-php/pull/86): Add configuration option for `proxy` and `redirects`
+2. [#92](https://github.com/influxdata/influxdb-client-php/pull/92): Add configuration option for `ipVersion`
 
 ### CI
 1. [#90](https://github.com/influxdata/influxdb-client-php/pull/90): Switch to next-gen CircleCI's convenience images

--- a/README.md
+++ b/README.md
@@ -412,8 +412,9 @@ As is known, sending via UDP occurs without waiting for a response, unlike TCP (
 
 UDP Writer Requirements:
 1. Installed ext-sockets
-1. Since Influxdb 2.0+ does not support UDP protocol natively you need to install and configure Telegraf plugin: https://docs.influxdata.com/telegraf/v1.16/plugins/#socket_listener
-1. Extra config option passed to client: udpPort. Optionally you can specify udpHost, otherwise udpHost will parsed from url option
+2. Since Influxdb 2.0+ does not support UDP protocol natively you need to install and configure Telegraf plugin: https://docs.influxdata.com/telegraf/v1.16/plugins/#socket_listener
+3. Extra config option passed to client: udpPort. Optionally you can specify udpHost, otherwise udpHost will parsed from url option
+4. Extra config option passed to client: ipVersion. Optionally you can specify the ip version, defaults to IPv4
  
 ```php
 $client = new InfluxDB2\Client(["url" => "http://localhost:8086", "token" => "my-token",
@@ -421,6 +422,7 @@ $client = new InfluxDB2\Client(["url" => "http://localhost:8086", "token" => "my
     "org" => "my-org",
     "precision" => InfluxDB2\Model\WritePrecision::NS,
     "udpPort" => 8094,
+    "ipVersion" => 6,
 ]);
 $writer = $client->createUdpWriter();
 $writer->write('h2o,location=west value=33i 15');

--- a/src/InfluxDB2/Client.php
+++ b/src/InfluxDB2/Client.php
@@ -35,7 +35,8 @@ class Client
      *          "logFile" => "php://output",
      *          "tags" => ['id' => '1234',
      *              'hostname' => '${env.Hostname}'],
-     *          "timeout" => 2
+     *          "timeout" => 2,
+     *          "ipVersion" => 6,
      *          ]);
      *
      * Client can be configured with following properties:
@@ -52,6 +53,7 @@ class Client
      * - timeout: The number of seconds to wait while trying to connect to a server. Use 0 to wait indefinitely.
      * - proxy: Pass a string to specify an HTTP proxy, or an array to specify different proxies for different protocols.
      * - allow_redirects: Describes the redirect behavior for requests.
+     * - ipVersion: Specifies which version of IP to use, supports 4 and 6 as possible values.
      *
      * @param array $options
      */

--- a/src/InfluxDB2/Client.php
+++ b/src/InfluxDB2/Client.php
@@ -53,7 +53,7 @@ class Client
      * - timeout: The number of seconds to wait while trying to connect to a server. Use 0 to wait indefinitely.
      * - proxy: Pass a string to specify an HTTP proxy, or an array to specify different proxies for different protocols.
      * - allow_redirects: Describes the redirect behavior for requests.
-     * - ipVersion: Specifies which version of IP to use, supports 4 and 6 as possible values.
+     * - ipVersion: Specifies which version of IP to use, supports 4 and 6 as possible values (UDP Writer).
      *
      * @param array $options
      */

--- a/src/InfluxDB2/UdpWriter.php
+++ b/src/InfluxDB2/UdpWriter.php
@@ -84,13 +84,32 @@ class UdpWriter implements Writer
     /**
      * Create (if not exists) socket to write UDP datagrams
      * @return false|resource
+     * @throws \Exception
      */
     protected function getSocket()
     {
         if (empty($this->socket)) {
-            $this->socket = socket_create(AF_INET, SOCK_DGRAM, SOL_UDP);
+            $this->socket = socket_create($this->getConfiguredInetVersion(), SOCK_DGRAM, SOL_UDP);
         }
         return $this->socket;
+    }
+
+    /**
+     * @throws \Exception
+     * @return int socket domain constant
+     */
+    private function getConfiguredInetVersion()
+    {
+        $configuredIpVersion = $this->options['ipVersion'] ?? 4;
+
+        switch ($configuredIpVersion) {
+            case 4:
+                return AF_INET;
+            case 6:
+                return AF_INET6;
+            default:
+                throw new \Exception('ipVersion option invalid!');
+        }
     }
 
     /**


### PR DESCRIPTION
Closes #91 

## Proposed Changes

New configuration option for IPv4 or IPv6

## Checklist

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `make test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
