### PR TITLE
chore: switch the PHP 7.1 image to next-gen CircleCI's convenience images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,7 @@ workflows:
           guzzle-version: "^6"
       - tests-php:
           name: php-7.1
-          php-image: "circleci/php:7.1"
+          php-image: "cimg/php:7.1"
           guzzle-version: "^6"
       - tests-windows:
           name: php-windows


### PR DESCRIPTION
## Proposed Changes

The https://github.com/CircleCI-Public/cimg-php/issues/1 also introduces support for PHP 7.1 => we are able to switch our config to new image.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `make test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
