### PR TITLE
fix: Fix file descriptor leaks in WriteApi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 2.3.0 [unreleased]
 
+### Bug Fixes
+1. [#95](https://github.com/influxdata/influxdb-client-php/pull/95): Fix file descriptor leaks in WriteApi
+
 ## 2.2.0 [2021-09-17]
 
 ### Features

--- a/src/InfluxDB2/Client.php
+++ b/src/InfluxDB2/Client.php
@@ -118,6 +118,7 @@ class Client
         foreach ($this->autoCloseable as $ac) {
             $ac->close();
         }
+        $this->autoCloseable = [];
     }
 
     public function getConfiguration()

--- a/src/InfluxDB2/WriteApi.php
+++ b/src/InfluxDB2/WriteApi.php
@@ -149,7 +149,9 @@ class WriteApi extends DefaultApi implements Writer
     {
         $this->closed = true;
 
-        $this->worker()->flush();
+        if (isset($this->worker)) {
+            $this->worker()->flush();
+        }
     }
 
     private function worker(): Worker

--- a/src/InfluxDB2/WriteApi.php
+++ b/src/InfluxDB2/WriteApi.php
@@ -152,6 +152,8 @@ class WriteApi extends DefaultApi implements Writer
         if (isset($this->worker)) {
             $this->worker()->flush();
         }
+
+        unset($this->worker);
     }
 
     private function worker(): Worker


### PR DESCRIPTION
## Proposed Changes

### disable creation of WriteApi worker on close

When a worker is created for a flush of the worker on close, it will just create a new object which makes it harder for for the garbage collector to correctly free the unused objects because the Worker itself has a reference to the WriteApi object it called. This is especially frustrating for WriteType::SYNCHRONOUS which doesn't need workers at all.

---

### ensure worker are destroyed after WriteApi::close

The worker will be flushed when something calls close on the WriteApi. But the worker will still continue to hold an reference to the WriteApi. This prevents an easy cleanup of the WriteApi by the (non-cyclic) garbage collector.

---

### clear Client::autoCloseable on close

The autoCloseable list of a client is only growing but is never cleared. This causes problems with the reference based garbage collection. But there is nothing more to process when all writers were closed.

This problem can often be seen on a system that each call of client->createWriteApi (on the same "global" client) followed by a ->write() will leak one or more file descriptor(s).


---

## Checklist


- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [ ] A test has been added if appropriate
- [ ] `make test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)