### PR TITLE
fix: nanosecond datetime string convertor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Bug Fixes
 1. [#95](https://github.com/influxdata/influxdb-client-php/pull/95): Fix file descriptor leaks in WriteApi
+1. [#96](https://github.com/influxdata/influxdb-client-php/pull/96): Fix nanosecond datetime string convertor
 
 ## 2.2.0 [2021-09-17]
 

--- a/src/InfluxDB2/ObjectSerializer.php
+++ b/src/InfluxDB2/ObjectSerializer.php
@@ -326,6 +326,7 @@ class ObjectSerializer
             return $instance;
         }
     }
+
     /**
     * Nano precision is not supported while decoding RFC 3339 formatted date/times.
     * https://bugs.php.net/bug.php?id=6481
@@ -337,9 +338,9 @@ class ObjectSerializer
     */
     static function fixDatetimeNanos(string $date) : string {
         $dateParts = explode(".", $date);
-        $nanosZ = $dateParts[1];
-        $posZ = strpos($nanosZ, 'Z');
+        $nanosZ = $dateParts[1] ?? "";
         if (strlen($nanosZ) > 9) {
+            $posZ = strpos($nanosZ, 'Z');
             $converted = $dateParts[0] . "." . substr($nanosZ, 0, 8);
             if ($posZ > 0) {
                 $converted .= "Z";
@@ -349,5 +350,4 @@ class ObjectSerializer
             return $date;
         }
     }
-
 }

--- a/tests/ITBucketServiceTest.php
+++ b/tests/ITBucketServiceTest.php
@@ -53,6 +53,11 @@ class ITBucketServiceTest extends IntegrationBaseTestCase
             "2020-09-18T08:03:48.12345678Z",
             ObjectSerializer::fixDatetimeNanos("2020-09-18T08:03:48.1234567899Z")
         );
+
+        self::assertEquals(
+            "2021-09-29T06:32:56Z",
+            ObjectSerializer::fixDatetimeNanos("2021-09-29T06:32:56Z")
+        );
     }
 
     public function testBucketService()

--- a/tests/ITTaskServiceTest.php
+++ b/tests/ITTaskServiceTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use InfluxDB2\Model\TaskCreateRequest;
+use InfluxDB2\Service\TasksService;
+
+require_once('IntegrationBaseTestCase.php');
+
+/**
+ * @group integration
+ */
+class ITTaskServiceTest extends IntegrationBaseTestCase
+{
+    public function testCreateTask()
+    {
+        /** @var TasksService $taskService */
+        $taskService = $this->client->createService(TasksService::class);
+
+        $flux = "option task = {
+  name: \"task-name\",
+  every: 6h
+}
+from(bucket: \"telegraf\") |> range(start: -1h)
+";
+
+        $taskCreateRequest = new TaskCreateRequest();
+        $taskCreateRequest
+            ->setFlux($flux)
+            ->setOrgId($this->findMyOrg()->getId());
+
+        $task = $taskService->postTasks($taskCreateRequest);
+
+        self::assertEquals("task-name", $task->getName());
+    }
+}


### PR DESCRIPTION
Closes #94

## Proposed Changes

Some APIs can return date without nanosecond precision.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `make test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
