### PR TITLE
fix: parsing response with new lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 2.4.0 [unreleased]
 
+### Bug Fixes
+1. [#101](https://github.com/influxdata/influxdb-client-php/pull/101): Fix parsing Query response with contains new lines in field values
+
 ## 2.3.0 [2021-10-22]
 
 ### Features

--- a/src/InfluxDB2/FluxCsvParser.php
+++ b/src/InfluxDB2/FluxCsvParser.php
@@ -73,7 +73,7 @@ class FluxCsvParser
     public function each()
     {
         try {
-            while (($csv = fgetcsv($this->resource)) !== FALSE) {
+            while (($csv = fgetcsv($this->resource)) !== false) {
                 if (!isset($csv) || (count($csv) == 1 && $csv[0] == null)) {
                     continue;
                 }

--- a/tests/QueryApiIntegrationTest.php
+++ b/tests/QueryApiIntegrationTest.php
@@ -76,7 +76,8 @@ class QueryApiIntegrationTest extends TestCase
         $this->assertEquals('level', $record->getField());
     }
 
-    public function testWriteQueryNewLine() {
+    public function testWriteQueryNewLine()
+    {
         $measurement = 'h2o_QueryNewLine_' . (new DateTime())->getTimestamp();
 
         $this->writeApi->write(Point::measurement($measurement)

--- a/tests/QueryApiIntegrationTest.php
+++ b/tests/QueryApiIntegrationTest.php
@@ -76,6 +76,25 @@ class QueryApiIntegrationTest extends TestCase
         $this->assertEquals('level', $record->getField());
     }
 
+    public function testWriteQueryNewLine() {
+        $measurement = 'h2o_QueryNewLine_' . (new DateTime())->getTimestamp();
+
+        $this->writeApi->write(Point::measurement($measurement)
+            ->addTag('location', 'europe')
+            ->addField('value', "some \n value"));
+
+        $result = $this->queryApi->query('from(bucket: "my-bucket") |> range(start: 0)
+            |> filter(fn: (r) => r._measurement == "' . $measurement . '")');
+
+        $this->assertNotNull($result);
+        $this->assertEquals(1, sizeof($result));
+        $records = $result[0]->records;
+        $this->assertEquals(1, sizeof($records));
+        $record = $records[0];
+
+        $this->assertEquals("some \r\n value", $record->getValue());
+    }
+
     /**
      * @param string $measurement
      * @param DateTime $now


### PR DESCRIPTION
Closes #100 

## Proposed Changes

Use [`fgetcsv`](https://www.php.net/manual/en/function.fgetcsv.php) for parsing lines of annotated CSV.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `make test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
