### PR TITLE
chore: drop support for PHP 7.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,16 +37,10 @@ commands:
     parameters:
       php-image:
         type: string
-      guzzle-version:
-        type: string
-      guzzle-psr-version:
-        type: string
     steps:
       - restore_cache:
           name: Restoring Composer Cache
           keys:
-              - composer-v3-{{ checksum "composer.json" }}-<< parameters.php-image >>-<< parameters.guzzle-version >>-<< parameters.guzzle-psr-version >>
-              - composer-v3-{{ checksum "composer.json" }}-<< parameters.php-image >>-<< parameters.guzzle-version >>
               - composer-v3-{{ checksum "composer.json" }}-<< parameters.php-image >>
               - composer-v3-{{ checksum "composer.json" }}
               - composer-v3-
@@ -54,7 +48,6 @@ commands:
           name: Install dependencies
           command: |
             composer install -n --prefer-dist
-            composer require guzzlehttp/guzzle:<< parameters.guzzle-version >> guzzlehttp/psr7:<< parameters.guzzle-psr-version >>
       - run:
           name: Run tests
           command: |
@@ -83,12 +76,6 @@ jobs:
       influxdb-image:
         type: string
         default: &default-influxdb-image "influxdb:latest"
-      guzzle-version:
-        type: string
-        default: "^7"
-      guzzle-psr-version:
-        type: string
-        default: "^1.7"
     docker:
       - image: << parameters.php-image >>
       - image: &influx-image << parameters.influxdb-image >>
@@ -98,8 +85,6 @@ jobs:
       - prepare
       - test:
           php-image: << parameters.php-image >>
-          guzzle-version: << parameters.guzzle-version>>
-          guzzle-psr-version: << parameters.guzzle-psr-version>>
       - storing-test-results
   tests-windows:
     machine:
@@ -140,10 +125,6 @@ workflows:
           name: php-8.1
           php-image: "cimg/php:8.1"
       - tests-php:
-          name: php-7.4-guzzle-7
-          guzzle-version: "7.0.1"
-          guzzle-psr-version: "^1.7"
-      - tests-php:
           name: php-7.4-nightly
           influxdb-image: "quay.io/influxdb/influxdb:nightly"
       - tests-php:
@@ -152,13 +133,6 @@ workflows:
       - tests-php:
           name: php-7.2
           php-image: "cimg/php:7.2"
-          guzzle-version: "^6"
-          guzzle-psr-version: "^1.7"
-      - tests-php:
-          name: php-7.1
-          php-image: "cimg/php:7.1"
-          guzzle-version: "^6"
-          guzzle-psr-version: "^1.7"
       - tests-windows:
           name: php-windows
       - check-code-style

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
-## 2.6.0 [unreleased]
+## 3.0.0 [unreleased]
+
+### Features
+1. [#114](https://github.com/influxdata/influxdb-client-php/pull/114): Minimal supported version of PHP is `7.2`
 
 ## 2.5.0 [2022-01-20]
 
 ### Features
 1. [#105](https://github.com/influxdata/influxdb-client-php/pull/105): Add support for latest `guzzlehttp/psr7"`
 1. [#107](https://github.com/influxdata/influxdb-client-php/pull/107): Add support for Parameterized Queries
-1. [#111](https://github.com/influxdata/influxdb-client-php/pull/111): Using ArrayAcces in FluxRecord
+1. [#111](https://github.com/influxdata/influxdb-client-php/pull/111): Using `ArrayAccess` in `FluxRecord`
 
 ### Bug Fixes
 1. [#109](https://github.com/influxdata/influxdb-client-php/pull/109): PHP 8.1 deprecation warnings

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.1-cli AS dev
+FROM php:7.2-cli AS dev
 
 COPY --from=composer /usr/bin/composer /usr/bin/
 
@@ -7,4 +7,4 @@ RUN yes | pecl install xdebug \
     && echo "xdebug.remote_enable=on" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.remote_autostart=on" >> /usr/local/etc/php/conf.d/xdebug.ini
 
-RUN apt-get update && apt-get -y install git procps make zsh
+RUN apt-get update && apt-get -y install git procps make zsh unzip

--- a/composer.json
+++ b/composer.json
@@ -7,12 +7,12 @@
   "homepage": "https://www.github.com/influxdata/influxdb-client-php",
   "license": "MIT",
   "require": {
-    "php": ">=7.1",
+    "php": ">=7.2",
     "ext-curl": "*",
     "ext-json": "*",
     "ext-mbstring": "*",
-    "guzzlehttp/guzzle": "^6.2|^7.0.1",
-    "guzzlehttp/psr7": "^1.7|^2.0.0"
+    "guzzlehttp/guzzle": "^7.0.1",
+    "guzzlehttp/psr7": "^2.0.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^7.4|^9.1",


### PR DESCRIPTION
Closes #112
Closes #113

## Proposed Changes

Drop supports for PHP 7.1. The v `7.1` is not supported by the Guzzle:

![image](https://user-images.githubusercontent.com/455137/150756450-d8074297-0992-485a-9c42-7d64739ad2d3.png)

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `make test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
