### PR TITLE
fix: add missing PermissionResource types from Cloud definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Features
 1. [#114](https://github.com/influxdata/influxdb-client-php/pull/114): Minimal supported version of PHP is `7.2`
 
+### Bug Fixes
+1. [#115](https://github.com/influxdata/influxdb-client-php/pull/115): Add missing PermissionResources from Cloud API definition
+
 ## 2.5.0 [2022-01-20]
 
 ### Features

--- a/src/InfluxDB2/Model/PermissionResource.php
+++ b/src/InfluxDB2/Model/PermissionResource.php
@@ -198,8 +198,10 @@ class PermissionResource implements ModelInterface, ArrayAccess
     const TYPE_DBRP = 'dbrp';
     const TYPE_NOTEBOOKS = 'notebooks';
     const TYPE_ANNOTATIONS = 'annotations';
-
-
+    const TYPE_REMOTES = 'remotes';
+    const TYPE_REPLICATIONS = 'replications';
+    const TYPE_FLOWS = 'flows';
+    const TYPE_FUNCTIONS = 'functions';
 
     /**
      * Gets allowable values of the enum
@@ -229,6 +231,10 @@ class PermissionResource implements ModelInterface, ArrayAccess
             self::TYPE_DBRP,
             self::TYPE_NOTEBOOKS,
             self::TYPE_ANNOTATIONS,
+            self::TYPE_REMOTES,
+            self::TYPE_REPLICATIONS,
+            self::TYPE_FLOWS,
+            self::TYPE_FUNCTIONS,
         ];
     }
 


### PR DESCRIPTION
## Proposed Changes

Added missing `PermissionResource` types.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `make test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
