### PR TITLE
feat: Using `DateTimeInterface` to be more compatible with all `DateTime`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 1. [#114](https://github.com/influxdata/influxdb-client-php/pull/114): Minimal supported version of PHP is `7.2`
+2. [#117](https://github.com/influxdata/influxdb-client-php/pull/117): Using `DateTimeInterface` to be more compatible with all `DateTime` objects (like `DateTimeImmutable`) in `Point`
 
 ### Bug Fixes
 1. [#115](https://github.com/influxdata/influxdb-client-php/pull/115): Add missing PermissionResources from Cloud API definition

--- a/src/InfluxDB2/Point.php
+++ b/src/InfluxDB2/Point.php
@@ -2,7 +2,7 @@
 
 namespace InfluxDB2;
 
-use DateTime;
+use DateTimeInterface;
 use InfluxDB2\Model\WritePrecision;
 
 class Point
@@ -218,7 +218,7 @@ class Point
 
         if (is_double($time) || is_float($time)) {
             $time = round($time);
-        } elseif ($time instanceof DateTime) {
+        } elseif ($time instanceof DateTimeInterface) {
             $seconds = $time->getTimestamp();
 
             switch ($this->precision) {

--- a/tests/PointTest.php
+++ b/tests/PointTest.php
@@ -3,6 +3,7 @@
 namespace InfluxDB2Test;
 
 use DateTime;
+use DateTimeImmutable;
 use InfluxDB2\Model\WritePrecision;
 use InfluxDB2\Point;
 use PHPUnit\Framework\TestCase;
@@ -149,12 +150,11 @@ class PointTest extends TestCase
         $this->assertEquals('h2o,location=europe level=2i 123', $point->toLineProtocol());
     }
 
-    public function testTimeFormatting()
+    /**
+     * @dataProvider providerDateTime
+     */
+    public function testTimeFormatting($time)
     {
-        $time = new DateTime();
-        $time->setDate(2015, 10, 15);
-        $time->setTime(8, 20, 15);
-
         $point = Point::measurement('h2o')
             ->addTag('location', 'europe')
             ->addField('level', 2)
@@ -182,6 +182,22 @@ class PointTest extends TestCase
             ->time($time, WritePrecision::NS);
 
         $this->assertEquals('h2o,location=europe level=2i 1444897215000000000', $point->toLineProtocol());
+    }
+
+    public function providerDateTime()
+    {
+        return [
+            [
+                (new DateTime())
+                    ->setDate(2015, 10, 15)
+                    ->setTime(8, 20, 15)
+            ],
+            [
+                (new DateTimeImmutable())
+                    ->setDate(2015, 10, 15)
+                    ->setTime(8, 20, 15)
+            ],
+        ];
     }
 
     public function testTimeFormattingDefault()


### PR DESCRIPTION
Using `DateTimeInterface` to be more compatible with all `DateTime` objects (like `DateTimeImmutable`) in `Point`.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `make test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
