### PR TITLE
chore(ci): use new codecov uploader for reporting code coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,10 @@ commands:
           command: |
             composer install -n --prefer-dist
       - run:
+          name: Install xdebug
+          command: |
+            sudo pecl install xdebug
+      - run:
           name: Run tests
           command: |
             export XDEBUG_MODE=coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,8 +54,16 @@ commands:
             export XDEBUG_MODE=coverage
             vendor/bin/phpunit tests --coverage-clover=coverage.xml
       - run:
-          name: "Collecting coverage reports"
-          command: bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
+          name: Collecting coverage reports
+          command: |
+            curl -Os https://uploader.codecov.io/latest/linux/codecov
+            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
+            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+            curl -s https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
+            gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+            shasum -a 256 -c codecov.SHA256SUM
+            chmod +x ./codecov
+            ./codecov
       - save_cache:
           name: Saving Cache
           key: composer-v3-{{ checksum "composer.json" }}-<< parameters.php-image >>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 2.7.0 [unreleased]
 
+### CI
+1. [#118](https://github.com/influxdata/influxdb-client-php/pull/118): Use new Codecov uploader for reporting code coverage
+
 ## 2.6.0 [2022-02-18]
 
 ### Features


### PR DESCRIPTION
## Proposed Changes

The Codecov Bash Uploader is deprecated - https://docs.codecov.com/docs/about-the-codecov-bash-uploader. We have to switch to new one - https://docs.codecov.com/docs/codecov-uploader.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `make test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
