### PR TITLE
feat: add FluxRecord.row with response data stored in Array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 3.1.0 [unreleased]
 
+### Features
+1. [#131](https://github.com/influxdata/influxdb-client-php/pull/131): Added `FluxRecord.row` which stores response data in a array
+
+
 ## 3.0.0 [2022-09-30]
 
 :warning: This release drops strong couple to [Guzzle HTTP client](https://github.com/guzzle/guzzle). 

--- a/examples/README.md
+++ b/examples/README.md
@@ -20,3 +20,5 @@
 - [InfluxDB_18_Example.php](InfluxDB_18_Example.php) - How to use forward compatibility APIs from InfluxDB 1.8
 - [DeleteDataExample.php](DeleteDataExample.php) - How to delete data from InfluxDB by client
 - [InvokableScripts.php](InvokableScripts.php) - How to use Invokable scripts Cloud API to create custom endpoints that query data
+- [RecordRowExample.php](RecordRowExample.php) - How to use `FluxRecord.row` instead of `FluxRecord.values`,
+  in case of duplicity column names

--- a/examples/RecordRowExample.php
+++ b/examples/RecordRowExample.php
@@ -28,8 +28,9 @@ $client = new Client([
 //
 $writeApi = $client->createWriteApi();
 
-foreach (range(1, 5) as $i)
+foreach (range(1, 5) as $i) {
     $writeApi->write("point,table=my-table result={$i}", InfluxDB2\Model\WritePrecision::MS, $bucket, $org);
+}
 
 $writeApi->close();
 
@@ -47,15 +48,19 @@ $result = $queryApi->query(
 // Write data to output
 //
 printf("\n--------------------------------------- FluxRecord.values ----------------------------------------\n");
-foreach ($result as $table) foreach ($table->records as $record) {
-    $values = implode(", ",$record->values);
-    print "{$values}\n";
+foreach ($result as $table) {
+    foreach ($table->records as $record) {
+        $values = implode(", ", $record->values);
+        print "{$values}\n";
+    }
 }
 
 printf("\n----------------------------------------- FluxRecord.row -----------------------------------------\n");
-foreach ($result as $table) foreach ($table->records as $record) {
-    $row = implode(", ", $record->row);
-    print "{$row}\n";
+foreach ($result as $table) {
+    foreach ($table->records as $record) {
+        $row = implode(", ", $record->row);
+        print "{$row}\n";
+    }
 }
 
 $client->close();

--- a/examples/RecordRowExample.php
+++ b/examples/RecordRowExample.php
@@ -29,7 +29,7 @@ $client = new Client([
 $writeApi = $client->createWriteApi();
 
 foreach (range(1, 5) as $i) {
-    $writeApi->write("point,table=my-table result={$i}", InfluxDB2\Model\WritePrecision::MS, $bucket, $org);
+    $writeApi->write("point,table=my-table result=$i", InfluxDB2\Model\WritePrecision::MS, $bucket, $org);
 }
 
 $writeApi->close();
@@ -40,7 +40,7 @@ $writeApi->close();
 $queryApi = $client->createQueryApi();
 
 $result = $queryApi->query(
-    "from(bucket: \"{$bucket}\") |> range(start: -1m) |> filter(fn: (r) => (r[\"_measurement\"] == \"point\"))
+    "from(bucket: \"$bucket\") |> range(start: -1m) |> filter(fn: (r) => (r[\"_measurement\"] == \"point\"))
 |> pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")"
 );
 
@@ -51,7 +51,7 @@ printf("\n--------------------------------------- FluxRecord.values ------------
 foreach ($result as $table) {
     foreach ($table->records as $record) {
         $values = implode(", ", $record->values);
-        print "{$values}\n";
+        print "$values\n";
     }
 }
 
@@ -59,7 +59,7 @@ printf("\n----------------------------------------- FluxRecord.row -------------
 foreach ($result as $table) {
     foreach ($table->records as $record) {
         $row = implode(", ", $record->row);
-        print "{$row}\n";
+        print "$row\n";
     }
 }
 

--- a/examples/RecordRowExample.php
+++ b/examples/RecordRowExample.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * How to use `FluxRecord.row` instead of `FluxRecord.values`
+ */
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use InfluxDB2\Client;
+
+$org = 'my-org';
+$bucket = 'my-bucket';
+$token = 'my-token';
+
+//
+// Creating client
+//
+$client = new Client([
+    "url" => "http://localhost:8086",
+    "token" => $token,
+    "bucket" => $bucket,
+    "org" => $org,
+    "precision" => InfluxDB2\Model\WritePrecision::S
+]);
+
+//
+// Write test data into InfluxDB
+//
+$writeApi = $client->createWriteApi();
+
+foreach (range(1, 5) as $i)
+    $writeApi->write("point,table=my-table result={$i}", InfluxDB2\Model\WritePrecision::MS, $bucket, $org);
+
+$writeApi->close();
+
+//
+// Query data with pivot
+//
+$queryApi = $client->createQueryApi();
+
+$result = $queryApi->query(
+    "from(bucket: \"{$bucket}\") |> range(start: -1m) |> filter(fn: (r) => (r[\"_measurement\"] == \"point\"))
+|> pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")"
+);
+
+//
+// Write data to output
+//
+printf("\n--------------------------------------- FluxRecord.values ----------------------------------------\n");
+foreach ($result as $table) foreach ($table->records as $record) {
+    $values = implode(", ",$record->values);
+    print "{$values}\n";
+}
+
+printf("\n----------------------------------------- FluxRecord.row -----------------------------------------\n");
+foreach ($result as $table) foreach ($table->records as $record) {
+    $row = implode(", ", $record->row);
+    print "{$row}\n";
+}
+
+$client->close();

--- a/src/InfluxDB2/FluxCsvParser.php
+++ b/src/InfluxDB2/FluxCsvParser.php
@@ -201,7 +201,7 @@ class FluxCsvParser
         if (count($duplicates) > 0) {
             $duplicatesStr = implode(", ", $duplicates);
             print "The response contains columns with duplicated names: {$duplicatesStr}\n";
-            print "You should use the 'FluxRecord.row to access your data instead of 'FluxRecord.values'.";
+            print "You should use the 'FluxRecord.row' to access your data instead of 'FluxRecord.values'.";
         }
     }
 

--- a/src/InfluxDB2/FluxCsvParser.php
+++ b/src/InfluxDB2/FluxCsvParser.php
@@ -185,14 +185,17 @@ class FluxCsvParser
     private function addColumnNamesAndTags(FluxTable $table, array $csv)
     {
         $i = 1;
-        $duplicates = array();
 
+        foreach ($table->columns as $column) {
+            $column->label = $csv[$i];
+            $i++;
+        }
+
+        $duplicates = array();
         foreach (array_count_values($csv) as $label => $count) {
             if ($count > 1) {
                 $duplicates[] = $label;
             }
-            $table->columns[$i]->label = $label;
-            $i++;
         }
 
         if (count($duplicates) > 0) {

--- a/src/InfluxDB2/FluxCsvParser.php
+++ b/src/InfluxDB2/FluxCsvParser.php
@@ -185,16 +185,13 @@ class FluxCsvParser
     private function addColumnNamesAndTags(FluxTable $table, array $csv)
     {
         $i = 1;
-        $labels = array();
         $duplicates = array();
 
-        foreach ($table->columns as $column) {
-            $column->label = $csv[$i];
-            if (in_array($column->label, $labels)) {
-                $duplicates[] = $column->label;
-            } else {
-                $labels[] = $column->label;
+        foreach (array_count_values($csv) as $label => $count) {
+            if ($count > 1) {
+                $duplicates[] = $label;
             }
+            $table->columns[$i]->label = $label;
             $i++;
         }
 

--- a/src/InfluxDB2/FluxCsvParser.php
+++ b/src/InfluxDB2/FluxCsvParser.php
@@ -190,8 +190,11 @@ class FluxCsvParser
 
         foreach ($table->columns as $column) {
             $column->label = $csv[$i];
-            if (in_array($column->label, $labels)) $duplicates[] = $column->label;
-            else $labels[] = $column->label;
+            if (in_array($column->label, $labels)) {
+                $duplicates[] = $column->label;
+            } else {
+                $labels[] = $column->label;
+            }
             $i++;
         }
 

--- a/src/InfluxDB2/FluxCsvParser.php
+++ b/src/InfluxDB2/FluxCsvParser.php
@@ -147,7 +147,9 @@ class FluxCsvParser
         foreach ($table->columns as $fluxColumn) {
             $columnName = $fluxColumn->label;
             $strVal = $csv[$fluxColumn->index + 1];
-            $record->values[$columnName] = $this->toValue($strVal, $fluxColumn);
+            $value = $this->toValue($strVal, $fluxColumn);
+            $record->values[$columnName] = $value;
+            $record->row[] = $value;
         }
         return $record;
     }
@@ -183,9 +185,20 @@ class FluxCsvParser
     private function addColumnNamesAndTags(FluxTable $table, array $csv)
     {
         $i = 1;
-        foreach ($table->columns as &$column) {
+        $labels = array();
+        $duplicates = array();
+
+        foreach ($table->columns as $column) {
             $column->label = $csv[$i];
+            if (in_array($column->label, $labels)) $duplicates[] = $column->label;
+            else $labels[] = $column->label;
             $i++;
+        }
+
+        if (count($duplicates) > 0) {
+            $duplicatesStr = implode(", ", $duplicates);
+            print "The response contains columns with duplicated names: {$duplicatesStr}\n";
+            print "You should use the 'FluxRecord.row to access your data instead of 'FluxRecord.values'.";
         }
     }
 

--- a/src/InfluxDB2/FluxRecord.php
+++ b/src/InfluxDB2/FluxRecord.php
@@ -15,16 +15,18 @@ class FluxRecord implements ArrayAccess
 {
     public $table;
     public $values;
+    public $row;
 
     /**
      * FluxRecord constructor.
      * @param $table int table index
      * @param $values array array with record values, key is the column name
      */
-    public function __construct($table, $values=null)
+    public function __construct($table, $values = null, $row = null)
     {
         $this->table = $table;
         $this->values = $values;
+        $this->row = $row;
     }
 
     /**
@@ -70,7 +72,7 @@ class FluxRecord implements ArrayAccess
     /**
      * @return mixed record value for column named '_measurement'
      */
-    public function getMeasurement():string
+    public function getMeasurement(): string
     {
         return $this->getRecordValue('_measurement');
     }

--- a/tests/FluxCsvParserTest.php
+++ b/tests/FluxCsvParserTest.php
@@ -442,6 +442,28 @@ class FluxCsvParserTest extends TestCase
         $this->assertEquals(-INF, $tables[0]->records[11]->values['le']);
     }
 
+    public function testParseDuplicateColumnNames()
+    {
+        $data = "#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,double
+#group,false,false,true,true,false,true,true,false
+#default,_result,,,,,,,
+ ,result,table,_start,_stop,_time,_measurement,location,result
+,,0,2022-09-13T06:14:40.469404272Z,2022-09-13T06:24:40.469404272Z,2022-09-13T06:24:33.746Z,my_measurement,Prague,25.3
+,,0,2022-09-13T06:14:40.469404272Z,2022-09-13T06:24:40.469404272Z,2022-09-13T06:24:39.299Z,my_measurement,Prague,25.3
+,,0,2022-09-13T06:14:40.469404272Z,2022-09-13T06:24:40.469404272Z,2022-09-13T06:24:40.454Z,my_measurement,Prague,25.3
+";
+
+        $parser = new FluxCsvParser($data);
+        $tables = $parser->parse()->tables;
+
+        $this->assertEquals(1, sizeof($tables));
+        $this->assertEquals(3, sizeof($tables[0]->records));
+        $this->assertEquals(8, sizeof($tables[0]->columns));
+        $this->assertEquals(7, sizeof($tables[0]->records[0]->values));
+        $this->assertEquals(8, sizeof($tables[0]->records[0]->row));
+        $this->assertEquals(25.3, $tables[0]->records[0]->row[7]);
+    }
+
     private function assertColumns(array $columnHeaders, array $values)
     {
         $i = 0;


### PR DESCRIPTION
## Proposed Changes

Adding possibility of accessing response data in Array FluxRecord.row.

In case of using pivot on data, where field contains labels that occur by default in the annotated CSV (f.e. "result" or "table"), could be duplicated column names in response. In that case FluxRecord.values, which hold only unique keys, doesn't show complete data. This edge case is solved by using FluxRecord.row.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `make test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
