### PR TITLE
docs: remove unused `@template T` in Client phpdoc

### DIFF
--- a/src/InfluxDB2/Client.php
+++ b/src/InfluxDB2/Client.php
@@ -10,9 +10,6 @@ use ReflectionClass;
 use ReflectionException;
 use RuntimeException;
 
-/**
- * @template T
- */
 class Client
 {
     /**


### PR DESCRIPTION
This removes the redundant `@template T` phpdoc above the `Client` class.

the phpdoc currently breaks PHPStan checks, but I cannot find any use for it in the repository.