### PR TITLE
fix(ci): freeze xdebug version to 3.1.6 which also supports PHP 7.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ commands:
       - run:
           name: Install xdebug
           command: |
-            sudo pecl install xdebug
+            sudo pecl install xdebug-3.1.6
       - run:
           name: Run tests
           command: |


### PR DESCRIPTION
## Proposed Changes

This PR fixes nightly build by freezing the `xdebug` to version `3.1.6`. This version also supports `PHP 7.2`. For more info see: https://pecl.php.net/package-changelog.php?package=xdebug&release=3.2.0.


**Failing CI build**:

![image](https://user-images.githubusercontent.com/455137/206654968-697e4b16-8920-4b08-99c1-d745c7ee8f87.png)

https://app.circleci.com/pipelines/github/influxdata/influxdb-client-php/1538/workflows/0b67507c-e56c-41aa-b178-c7c9f0728267/jobs/4616

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] `make test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
