### PR TITLE
Fixes running tests on PHP 8 environments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM php:7.2-cli AS dev
 
 COPY --from=composer /usr/bin/composer /usr/bin/
 
-RUN yes | pecl install xdebug \
+RUN yes | pecl install xdebug-2.9.8 \
     && echo "zend_extension=$(find /usr/local/lib/php/extensions/ -name xdebug.so)" > /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.remote_enable=on" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.remote_autostart=on" >> /usr/local/etc/php/conf.d/xdebug.ini

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ dshell: ## Start Docker Shell for Local Development
 	@docker-compose run --entrypoint=bash --rm php
 
 deps: ## Installs the project dependencies
-	@composer install
+	@docker-compose run php composer install
 
 test: start-server ## Perform unit tests
 	@docker-compose run php composer run test

--- a/README.md
+++ b/README.md
@@ -631,8 +631,15 @@ For more info see Redirect Plugin docs - [allow_redirects](https://docs.php-http
 
 ## Local tests
 
+Run once to install dependencies:
+
 ```shell script
-# run unit & integration tests
+make deps
+```
+
+Run unit & intergration tests:
+
+```shell script
 make test
 ```
 


### PR DESCRIPTION
## Proposed Changes

When running the test suite on a PHP 8 environment and running Composer locally, will install PHP 8 dependencies. This commit forces Composer to run in the target container with the same environment in which the tests run.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] Rebased/mergeable
- [X] `make test` completes successfully
- [X] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
