### PR TITLE
refactor: Fixes strings to prevent PHP 8.2 notices

### DIFF
--- a/examples/InvokableScripts.php
+++ b/examples/InvokableScripts.php
@@ -74,7 +74,7 @@ print "\n------- Invoke to FluxTables -------\n";
 $tables = $scriptsApi->invokeScript($createdScript->getId(), ["bucket_name" => $bucket]);
 foreach ($tables as $table) {
     foreach ($table->records as $record) {
-        print "\n${record['time']} ${record['location']}: ${record['_field']} ${record['_value']}";
+        print "\n{$record['time']} {$record['location']}: {$record['_field']} {$record['_value']}";
     }
 }
 
@@ -85,7 +85,7 @@ print "\n";
 print "\n------- Invoke to Stream of FluxRecords -------\n";
 $records = $scriptsApi->invokeScriptStream($createdScript->getId(), ["bucket_name" => $bucket]);
 foreach ($records->each() as $record) {
-    print "\n${record['time']} ${record['location']}: ${record['_field']} ${record['_value']}";
+    print "\n{$record['time']} {$record['location']}: {$record['_field']} {$record['_value']}";
 }
 
 //
@@ -94,7 +94,7 @@ foreach ($records->each() as $record) {
 print "\n";
 print "\n------- Invoke to Raw-------\n";
 $raw = $scriptsApi->invokeScriptRaw($createdScript->getId(), ["bucket_name" => $bucket]);
-print "RAW output:\n\n ${raw}";
+print "RAW output:\n\n {$raw}";
 
 //
 // List scripts

--- a/src/InfluxDB2/DefaultApi.php
+++ b/src/InfluxDB2/DefaultApi.php
@@ -200,7 +200,7 @@ class DefaultApi
                 $this->options,
                 array_keys($this->options)
             ));
-            throw new InvalidArgumentException("The '${key}' should be defined as argument or default option: {$options}");
+            throw new InvalidArgumentException("The '{$key}' should be defined as argument or default option: {$options}");
         }
     }
 

--- a/src/InfluxDB2/InvokableScriptsApi.php
+++ b/src/InfluxDB2/InvokableScriptsApi.php
@@ -133,6 +133,6 @@ class InvokableScriptsApi extends DefaultApi
 
     private function _invokeScript(ScriptInvocationParams $invocation_params, string $scriptId): StreamInterface
     {
-        return $this->post($invocation_params->__toString(), "/api/v2/scripts/${scriptId}/invoke", [])->getBody();
+        return $this->post($invocation_params->__toString(), "/api/v2/scripts/{$scriptId}/invoke", [])->getBody();
     }
 }


### PR DESCRIPTION
## Proposed Changes

PHP 8.2 throws deprecation notices on this string interpolation syntax. Does not affect the environment variable syntax in the config settings. No functional changes, backward compatible with PHP 7.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [X] Rebased/mergeable
- [X] `make test` completes successfully
- [X] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
