### PR TITLE
fix: close the UdpWriter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 3.4.0 [unreleased]
 
+1. [#144](https://github.com/influxdata/influxdb-client-php/pull/144): fix: close the UdpWriter
+
 ## 3.3.0 [2023-03-29]
 
 ### Others

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.4.0 [unreleased]
 
-1. [#144](https://github.com/influxdata/influxdb-client-php/pull/144): fix: close the UdpWriter
+### Bug Fixes
+1. [#144](https://github.com/influxdata/influxdb-client-php/pull/144): Correcti closing the UdpWriter
 
 ## 3.3.0 [2023-03-29]
 

--- a/src/InfluxDB2/UdpWriter.php
+++ b/src/InfluxDB2/UdpWriter.php
@@ -119,6 +119,8 @@ class UdpWriter implements Writer
     {
         if (isset($this->socket)) {
             socket_close($this->socket);
+
+            $this->socket = null;
         }
     }
 }


### PR DESCRIPTION
## Proposed Changes

If UPD socket was previously closed by `\InfluxDB2\UdpWriter::close` and new write occured, error will be obtained `socket_sendto(): Argument #1 ($socket) has already been closed`

```
    $writeApi = $client->createUdpWriter();
    $writeApi->write("weather,location=Tokio temperature=$temp $seconds");
    $writeApi->close();
    $writeApi->write("weather,location=Tokio temperature=$temp $seconds"); // uses link to closed socket
```

This is because method `close` does not unset socket property:

```
    public function close()
    {
        if (isset($this->socket)) {
            socket_close($this->socket);
        }
    }
```

And `getSocket` does not create new connection because old still in `socket` property:

```
    protected function getSocket()
    {
        if (empty($this->socket)) {
            $this->socket = socket_create($this->getConfiguredInetVersion(), SOCK_DGRAM, SOL_UDP);
        }
        return $this->socket;
    }
```

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `make test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
