### PR TITLE
feat: #145 try to convert non-string-tags to strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 3.5.0 [unreleased]
 
+1. [#146](https://github.com/influxdata/influxdb-client-php/pull/146): Try to convert non-string-tags to strings, throw an exception if a value cannot be converted
+
 ## 3.4.0 [2023-07-28]
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.5.0 [unreleased]
 
-1. [#146](https://github.com/influxdata/influxdb-client-php/pull/146): Try to convert non-string-tags to strings, throw an exception if a value cannot be converted
+### Bug Fixes
+1. [#146](https://github.com/influxdata/influxdb-client-php/pull/146): Try to convert non-string-tags to strings, generate a warning if a value cannot be converted
 
 ## 3.4.0 [2023-07-28]
 

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
   },
   "autoload-dev": {
     "psr-4": {
-      "InfluxDB2\\": "test/InfluxDB2"
+      "InfluxDB2Test\\": "tests/"
     }
   },
   "scripts": {

--- a/src/InfluxDB2/Point.php
+++ b/src/InfluxDB2/Point.php
@@ -77,7 +77,7 @@ class Point
     /** Adds or replaces a tag value for a point.
      *
      * @param [Object] key the tag name
-     * @param [Object] value the tag value
+     * @param string|object|null $value the tag value, can be "object" with "__toString" function or "object" implements Stringable interface
      * @return Point
      */
     public function addTag($key, ?string $value): Point

--- a/src/InfluxDB2/Point.php
+++ b/src/InfluxDB2/Point.php
@@ -80,7 +80,7 @@ class Point
      * @param [Object] value the tag value
      * @return Point
      */
-    public function addTag($key, $value): Point
+    public function addTag($key, ?string $value): Point
     {
         $this->tags[$key] = $value;
 
@@ -161,6 +161,18 @@ class Point
 
         foreach (array_keys($this->tags) as $key) {
             $value = $this->tags[$key];
+
+            if (!is_string($value) && null !== $value) {
+                if (
+                    is_scalar($value)  ||
+                    (is_object($value) && method_exists($value, '__toString')) ||
+                    (\PHP_VERSION_ID >= 80000 && $value instanceof \Stringable)
+                ) {
+                    $value = (string) $value;
+                } else {
+                    trigger_error(sprintf('Tag value for key %s cannot be converted to string', $key), E_USER_WARNING);
+                }
+            }
 
             if ($this->isNullOrEmptyString($key) || $this->isNullOrEmptyString($value)) {
                 continue;

--- a/tests/StringableClass.php
+++ b/tests/StringableClass.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace InfluxDB2Test;
+
+class StringableClass
+{
+    public function __toString()
+    {
+        return "stringable";
+    }
+}


### PR DESCRIPTION
Closes #145 

## Proposed Changes

- add a TypeHint to Point->addTag(). PHP will auto-convert scalars and stringable values. Null-Values are handled like before
- auto-convert scalars, objects with __toString() and stringable objects
- if the value cannot be converted, throw an exception

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `make test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
