### PR TITLE
Throw exception if no field is provided when calling toLineProtocol()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 3.5.0 [unreleased]
 
+1. [#149](https://github.com/influxdata/influxdb-client-php/issues/149): Throw exception on empty field
+
 ## 3.4.0 [2023-07-28]
 
 ### Bug Fixes

--- a/src/InfluxDB2/Point.php
+++ b/src/InfluxDB2/Point.php
@@ -114,9 +114,10 @@ class Point
         return $this;
     }
 
-    /** If there is no field then return null.
+    /** If there is no field then throw an exception.
      *
      * @return string representation of the point
+     * @throws \InvalidArgumentException when no field is provided
      */
     public function toLineProtocol()
     {
@@ -135,7 +136,7 @@ class Point
         $fields = $this->appendFields();
 
         if ($this->isNullOrEmptyString($fields)) {
-            return null;
+            throw new \InvalidArgumentException("Failed to write Point: At least one field is required.");
         }
 
         $lineProtocol .= $fields;

--- a/tests/PointTest.php
+++ b/tests/PointTest.php
@@ -6,6 +6,7 @@ use DateTime;
 use DateTimeImmutable;
 use InfluxDB2\Model\WritePrecision;
 use InfluxDB2\Point;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 class PointTest extends TestCase
@@ -262,11 +263,13 @@ class PointTest extends TestCase
 
     public function testWithoutFields()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $point = Point::measurement('h2o')
             ->addTag('location', 'europe')
             ->time(123);
 
-        $this->assertNull($point->toLineProtocol());
+        $point->toLineProtocol();
     }
 
     public function testFromArrayWithoutName()


### PR DESCRIPTION
Closes [#149](https://github.com/influxdata/influxdb-client-php/issues/149)

## Proposed Changes

toLineProtocol() will throw an exception if no field is provided. This prevents the data from being silently converted to null and discarded, thereby providing the developer with a clear error message, as fields are mandatory.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `make test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
