### PR TITLE
fix: More fool-proof error message handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 ## 3.6.0 [unreleased]
 
-## 3.5.1 [unreleased]
-
 ### Bug Fixes
 1. [#155](https://github.com/influxdata/influxdb-client-php/pull/155): Fixes error handling in some cases, throw ApiException instead of ErrorException about undefined property
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 3.6.0 [unreleased]
 
+## 3.5.1 [unreleased]
+
+### Bug Fixes
+1. [#155](https://github.com/influxdata/influxdb-client-php/pull/155): Fixes error handling in some cases, throw ApiException instead of ErrorException about undefined property
+
 ## 3.5.0 [2024-04-16]
 
 ### Bug Fixes

--- a/src/InfluxDB2/DefaultApi.php
+++ b/src/InfluxDB2/DefaultApi.php
@@ -166,7 +166,7 @@ class DefaultApi
                         '[%d] Error connecting to the API (%s)(%s)',
                         $statusCode,
                         $request->getUri(),
-                        $errorMessage,
+                        $errorMessage
                     ),
                     $statusCode,
                     $response->getHeaders(),

--- a/src/InfluxDB2/DefaultApi.php
+++ b/src/InfluxDB2/DefaultApi.php
@@ -154,12 +154,19 @@ class DefaultApi
             if ($statusCode < 200 || $statusCode > 299) {
                 $responseBody = $response->getBody()->getContents();
                 $jsonBody = json_decode($responseBody);
+                $errorMessage = $responseBody;
+                if (isset($jsonBody->message)) {
+                    $errorMessage = $jsonBody->message;
+                }
+                if (isset($jsonBody->error)) {
+                    $errorMessage = $jsonBody->error;
+                }
                 throw new ApiException(
                     sprintf(
                         '[%d] Error connecting to the API (%s)(%s)',
                         $statusCode,
                         $request->getUri(),
-                        $jsonBody ? ": {$jsonBody->message}" : ''
+                        $errorMessage,
                     ),
                     $statusCode,
                     $response->getHeaders(),

--- a/tests/DefaultApiTest.php
+++ b/tests/DefaultApiTest.php
@@ -120,6 +120,26 @@ class DefaultApiTest extends BasicTest
         $this->assertEquals('Token my-token', $this->getHeader($this->requests[1]['request']));
     }
 
+    public function testJsonBodyWithMessageReturnsMessage()
+    {
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessageMatches('~^\[500\].*\(a failure\)$~');
+        $this->mockHandler->append(
+            new Response(500, [], "{\"message\": \"a failure\"}")
+        );
+        $this->queryApi->query('some broken query');
+    }
+
+    public function testJsonBodyWithErrorReturnsMessage()
+    {
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessageMatches('~^\[500\].*\(another failure\)$~');
+        $this->mockHandler->append(
+            new Response(500, [], "{\"error\": \"another failure\"}")
+        );
+        $this->queryApi->query('some broken query');
+    }
+
     /**
      * @param Request $request with headers
      * @return string Authorization headers


### PR DESCRIPTION
## Proposed Changes

Changes the error thrown from something like this;
```
ErrorException
Undefined property: stdClass::$message
```

to something like this;
```
InfluxDB2\ApiException 
[500] Error connecting to the API (http://influxdb:8086/api/v2/query?org=-)(type error 1:35-1:76: function does not take a parameter "end", required params (start))
```

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `make test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
