### PR TITLE
fix: remove deprecation for implicitly nullable parameter types

### DIFF
--- a/src/InfluxDB2/WritePayloadSerializer.php
+++ b/src/InfluxDB2/WritePayloadSerializer.php
@@ -15,7 +15,7 @@ class WritePayloadSerializer
      * @param int|null $writeType specify type of writes - WriteType::SYNCHRONOUS or WriteType::BATCHING
      * @return BatchItem|string|null
      */
-    public static function generatePayload($data, string $precision = null, string $bucket = null, string $org = null, int $writeType = null)
+    public static function generatePayload($data, ?string $precision = null, ?string $bucket = null, ?string $org = null, ?int $writeType = null)
     {
         if ($data == null || empty($data)) {
             return null;


### PR DESCRIPTION
## Proposed Changes

Remove deprecation for implicitly nullable parameter types since php 8.4

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
