### PR TITLE
fix: PHP 8.4 - fgetcsv argument escape provided explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.7.0 [unreleased]
 
-[#162](https://github.com/influxdata/influxdb-client-php/issues/162): PHP 8.4 - fgetcsv() needs provide explicitly argument escape
+### Bug Fixes
+1. [#162](https://github.com/influxdata/influxdb-client-php/issues/162): PHP 8.4 - fgetcsv() needs provide explicitly argument escape
 
 ## 3.6.0 [2024-06-24]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 3.7.0 [unreleased]
 
+[#162](https://github.com/influxdata/influxdb-client-php/issues/162): PHP 8.4 - fgetcsv() needs provide explicitly argument escape
+
 ## 3.6.0 [2024-06-24]
 
 ### Bug Fixes

--- a/src/InfluxDB2/FluxCsvParser.php
+++ b/src/InfluxDB2/FluxCsvParser.php
@@ -76,7 +76,7 @@ class FluxCsvParser
     public function each()
     {
         try {
-            while (($csv = fgetcsv($this->resource)) !== false) {
+            while (($csv = fgetcsv($this->resource, escape: '')) !== false) {
                 if (!isset($csv) || (count($csv) == 1 && $csv[0] == null)) {
                     continue;
                 }

--- a/src/InfluxDB2/FluxCsvParser.php
+++ b/src/InfluxDB2/FluxCsvParser.php
@@ -76,7 +76,7 @@ class FluxCsvParser
     public function each()
     {
         try {
-            while (($csv = fgetcsv($this->resource, null, ',', '"', '')) !== false) {
+            while (($csv = fgetcsv($this->resource, null, ',', '"', '\\')) !== false) {
                 if (!isset($csv) || (count($csv) == 1 && $csv[0] == null)) {
                     continue;
                 }

--- a/src/InfluxDB2/FluxCsvParser.php
+++ b/src/InfluxDB2/FluxCsvParser.php
@@ -76,7 +76,7 @@ class FluxCsvParser
     public function each()
     {
         try {
-            while (($csv = fgetcsv($this->resource, escape: '')) !== false) {
+            while (($csv = fgetcsv($this->resource, null, ',', '"', '')) !== false) {
                 if (!isset($csv) || (count($csv) == 1 && $csv[0] == null)) {
                     continue;
                 }


### PR DESCRIPTION
Closes #162 

## Proposed Changes

Added argument `escape`.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
