### PR TITLE
fix: remove deprecation for implicitly nullable parameter types (replacement)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Bug Fixes
 1. [#162](https://github.com/influxdata/influxdb-client-php/issues/162): PHP 8.4 - fgetcsv() needs provide explicitly argument escape
+2. [#164](https://github.com/influxdata/influxdb-client-php/pull/164): Fixes deprecation warnings about implicitly nullable arguments
 
 ## 3.6.0 [2024-06-24]
 

--- a/src/InfluxDB2/WritePayloadSerializer.php
+++ b/src/InfluxDB2/WritePayloadSerializer.php
@@ -15,7 +15,7 @@ class WritePayloadSerializer
      * @param int|null $writeType specify type of writes - WriteType::SYNCHRONOUS or WriteType::BATCHING
      * @return BatchItem|string|null
      */
-    public static function generatePayload($data, string $precision = null, string $bucket = null, string $org = null, int $writeType = null)
+    public static function generatePayload($data, ?string $precision = null, ?string $bucket = null, ?string $org = null, ?int $writeType = null)
     {
         if ($data == null || empty($data)) {
             return null;


### PR DESCRIPTION
Replaces #161

## Proposed Changes

Remove deprecation for implicitly nullable parameter types since php 8.4

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `make test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
