### PR TITLE
Fix php deprecation - Implicitly marking parameter as nullable is dep…

### DIFF
--- a/src/InfluxDB2/Client.php
+++ b/src/InfluxDB2/Client.php
@@ -73,7 +73,7 @@ class Client
      * @param array|null $pointSettings Array of default tags
      * @return WriteApi
      */
-    public function createWriteApi(array $writeOptions = null, array $pointSettings = null): WriteApi
+    public function createWriteApi(?array $writeOptions = null, ?array $pointSettings = null): WriteApi
     {
         $writeApi = new WriteApi($this->options, $writeOptions, $pointSettings);
         $this->autoCloseable[] = $writeApi;


### PR DESCRIPTION
…recated

Deprecated: InfluxDB2\Client::createWriteApi(): Implicitly marking parameter $writeOptions as nullable is deprecated, the explicit nullable type must be used instead in /Users/cedriclombardot/getallmylinks/vendor/influxdata/influxdb-client-php/src/InfluxDB2/Client.php on line 76

Deprecated: InfluxDB2\Client::createWriteApi(): Implicitly marking parameter $pointSettings as nullable is deprecated, the explicit nullable type must be used instead in /Users/cedriclombardot/getallmylinks/vendor/influxdata/influxdb-client-php/src/InfluxDB2/Client.php on line 76
