### PR TITLE
docs: added missing Client Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ $client = new InfluxDB2\Client([
 | verifySSL        | Turn on/off SSL certificate verification. Set to `false` to disable certificate verification.             | :warning: required `Guzzle` HTTP client | bool                              | true         |
 | timeout          | Describing the number of seconds to wait while trying to connect to a server. Use 0 to wait indefinitely. | :warning: required `Guzzle` HTTP client | int                               | 10           |
 | proxy            | specify an HTTP proxy, or an array to specify different proxies for different protocols.                  | :warning: required `Guzzle` HTTP client | string                            | none         |
+| udpPort          | Port for the UDP connection                                                                               |                                         | int                               | none         |
+| ipVersion        | You can specify the ip version                                                                            |                                         | int (4 or 6)                      | 4            |
+| udpPort          | Host for the UDP connection, otherwise udpHost will parsed from url option                                |                                         | String                            | url host     |
+| tags             | default tags (e.g `"tags" => ['id' => '1234', 'hostname' => '${env.Hostname}'`]                           |                                         | array<String, String>             | none         |
 
 #### Custom HTTP client
 


### PR DESCRIPTION
## Proposed Changes

When migrating from the old [influxdata/influxdb-php](https://github.com/influxdata/influxdb-php) to the new [influxdata/influxdb-client-php](https://github.com/influxdata/influxdb-client-php) I noticed that some of the available client options (notably udp options) were missing from the Client Options-table.

This PR adds those missing options. I scanned quickly through the [Client.php](https://github.com/influxdata/influxdb-client-php/blob/master/src/InfluxDB2/Client.php) and also added`tags` and it was also missing.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] ~~CHANGELOG.md updated~~ (not applicable)
- [x] Rebased/mergeable
- [x] ~~A test has been added if appropriate~~ (not applicable)
- [x] `make test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
