### PR TITLE
fix: fix PHP 8.5 deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 3.9.0 [unreleased]
 
+### Bug Fixes
+1. [#170](https://github.com/influxdata/influxdb-client-php/pull/170): Fix PHP 8.5 deprecations.
+
 ### Others
 
 1. [#171](https://github.com/influxdata/influxdb-client-php/pull/171): Bring CI pipeline up to date.

--- a/src/InfluxDB2/FluxCsvParser.php
+++ b/src/InfluxDB2/FluxCsvParser.php
@@ -283,7 +283,7 @@ class FluxCsvParser
             if ($strVal == '-Inf') {
                 return -INF;
             }
-            return (double)$strVal;
+            return (float)$strVal;
         }
 
         if ('base64Binary' == $column->dataType) {

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -4,7 +4,6 @@ namespace InfluxDB2Test;
 
 use Exception;
 use InfluxDB2\Client;
-use IntegrationBaseTestCase;
 
 require_once('IntegrationBaseTestCase.php');
 

--- a/tests/DefaultApiTest.php
+++ b/tests/DefaultApiTest.php
@@ -156,7 +156,9 @@ class DefaultApiTest extends BasicTest
     {
         $reflection = new ReflectionObject($object);
         $property = $reflection->getProperty($property_name);
-        $property->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $property->setAccessible(true);
+        }
         return $property->getValue($object);
     }
 }

--- a/tests/FluxCsvParserTest.php
+++ b/tests/FluxCsvParserTest.php
@@ -515,7 +515,7 @@ class FluxCsvParserTest extends TestCase
     private function assertRecord(FluxRecord $fluxRecord, array $values, $size = 0, $value = null)
     {
         foreach ($values as $key => $val) {
-            $this->assertEquals($values[$key], $fluxRecord->values[$key]);
+            $this->assertEquals($val, $fluxRecord->values[$key]);
         }
 
         if ($value == null) {

--- a/tests/ITBucketServiceTest.php
+++ b/tests/ITBucketServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace InfluxDB2Test;
+
 use InfluxDB2\ApiException;
 use InfluxDB2\Model\BucketRetentionRules;
 use InfluxDB2\Model\PostBucketRequest;

--- a/tests/ITTaskServiceTest.php
+++ b/tests/ITTaskServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace InfluxDB2Test;
+
 use InfluxDB2\Model\TaskCreateRequest;
 use InfluxDB2\Service\TasksService;
 

--- a/tests/ITUsersServiceTest.php
+++ b/tests/ITUsersServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace InfluxDB2Test;
+
 use InfluxDB2\Service\UsersService;
 
 require_once('IntegrationBaseTestCase.php');

--- a/tests/IntegrationBaseTestCase.php
+++ b/tests/IntegrationBaseTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace InfluxDB2Test;
+
 use InfluxDB2\Client;
 use InfluxDB2\Model\Organization;
 use InfluxDB2\Model\WritePrecision;

--- a/tests/WriteUdpTest.php
+++ b/tests/WriteUdpTest.php
@@ -26,9 +26,11 @@ class WriteUdpTest extends TestCase
     protected function getWriterMock()
     {
         $method = new \ReflectionMethod(UdpWriter::class, 'writeSocket');
-        $method->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
         return $this->getMockBuilder(UdpWriter::class)
-            ->setMethods(['writeSocket'])
+            ->onlyMethods(['writeSocket'])
             ->setConstructorArgs([$this->baseConfig + ['udpPort' => 1000]])
             ->getMock();
     }


### PR DESCRIPTION
## Proposed Changes

 - Fixes PHP 8.5 deprecations:
   - [non-canonical scalar type casts](https://php.watch/versions/8.5/boolean-double-integer-binary-casts-deprecated) - `(double)` -> `(float)`
   - [ReflectionMethod::setAccessible](https://www.php.net/manual/en/reflectionmethod.setaccessible.php)

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [ ] A test has been added if appropriate
- [x] `make test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
