### PR TITLE
chore: update build to support PHP 8.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,14 +180,15 @@ workflows:
           php-image: "cimg/php:8.2"
           xdebug-package: "xdebug"
       - tests-php:
+          name: php-8.5
+          php-image: "cimg/php:8.5"
+          xdebug-package: "xdebug"
+      - tests-php:
           name: php-7.4-nightly
           influxdb-image: "quay.io/influxdb/influxdb:nightly"
       - tests-php:
           name: php-7.3
           php-image: "cimg/php:7.3"
-      - tests-php:
-          name: php-7.2
-          php-image: "cimg/php:7.2"
       - tests-windows:
           name: php-windows
       - tests-cURL:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ commands:
             curl -Os https://uploader.codecov.io/latest/linux/codecov
             curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
             curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
-            curl -s https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
+            curl -fsSL https://uploader.codecov.io/verification.gpg | gpg --no-default-keyring --keyring trustedkeys.gpg --import
             gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
             shasum -a 256 -c codecov.SHA256SUM
             chmod +x ./codecov

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## 3.9.0 [unreleased]
 
+### Others
+
+1. [#171](https://github.com/influxdata/influxdb-client-php/pull/171): Bring CI pipeline up to date.
+   - Remove PHP 7.2 from CI build.
+   - Add PHP 8.5 to CI build.
+
 ## 3.8.0 [2026-06-26]
 
 ### Bug Fixes


### PR DESCRIPTION
## Proposed Changes

* remove support for php-7.2, 
   * some dependencies require php-7.3 or higher, see [last broken build](https://app.circleci.com/pipelines/github/influxdata/influxdb-client-php/2950/workflows/6c9657de-f40e-46cb-8ba1-d158bb2d422f/jobs/6826)
   * N.B. removing support for this version in the CI pipeline is the quickest solution for a library we are now only maintaining.
* add support for php-8.5 
   * php 8.5.8 - was recently released and changes proposed in comunity supplied #170 should stabilize this build.  
   * community supplied #170 also shows community interest in maintaining support for this library for this PHP release.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [] A test has been added if appropriate - N.A.
- [x] `make test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
