### PR TITLE
chore: add suggested dependency on socket PHP extension because is required by UDP writer

### DIFF
--- a/.circleci/php.ini
+++ b/.circleci/php.ini
@@ -934,7 +934,7 @@ extension=openssl
 ;extension=snmp
 
 ;extension=soap
-;extension=sockets
+extension=sockets
 ;extension=sodium
 ;extension=sqlite3
 ;extension=tidy
@@ -1708,7 +1708,7 @@ zend.assertions = 1
 ;mbstring.http_output_conv_mimetype=
 
 ; This directive specifies maximum stack depth for mbstring regular expressions. It is similar
-; to the pcre.recursion_limit for PCRE. 
+; to the pcre.recursion_limit for PCRE.
 ; Default: 100000
 ;mbstring.regex_stack_limit=100000
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 1. [#171](https://github.com/influxdata/influxdb-client-php/pull/171): Bring CI pipeline up to date.
    - Remove PHP 7.2 from CI build.
    - Add PHP 8.5 to CI build.
+2. [#172](https://github.com/influxdata/influxdb-client-php/pull/172): Suggest dependency on `ext-sockets` for `InfluxDB2\UdpWriter`.
 
 ## 3.8.0 [2026-06-26]
 

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,9 @@
     "guzzlehttp/guzzle": "^7.0.1",
     "guzzlehttp/psr7": "^2.0.0"
   },
+  "suggest": {
+    "ext-sockets": "Required for UDP writer."
+  },
   "autoload": {
     "psr-4": {
       "InfluxDB2\\": "src/InfluxDB2"


### PR DESCRIPTION
## Proposed Changes
Adds dependency on PHP extension `ext-sockets` because `InfluxDB2\UdpWriter` uses functionality of this extension.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [ ] A test has been added if appropriate
- [x] `make test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
