### PR TITLE
docs: fix release date of version 3.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
    - Remove PHP 7.2 from CI build.
    - Add PHP 8.5 to CI build.
 
-## 3.8.0 [2026-06-26]
+## 3.8.0 [2025-06-26]
 
 ### Bug Fixes
 1. [#166](https://github.com/influxdata/influxdb-client-php/pull/166): Fix PHP 8.4 deprecated implicit nullable arguments. PHP minimum version is still PHP 7.2.


### PR DESCRIPTION
## Proposed Changes

Fixes release date of the version 3.8.0, see https://github.com/influxdata/influxdb-client-php/releases/tag/3.8.0.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [x] Rebased/mergeable
- [ ] A test has been added if appropriate
- [x] `make test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
