### PR TITLE
chore: use Docker compose v2+ in Makefile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
    - Remove PHP 7.2 from CI build.
    - Add PHP 8.5 to CI build.
 2. [#172](https://github.com/influxdata/influxdb-client-php/pull/172): Suggest dependency on `ext-sockets` for `InfluxDB2\UdpWriter`.
+3. [#175](https://github.com/influxdata/influxdb-client-php/pull/175): Use Docker Compose v2+ in Makefile since v1 is not maintained anymore.
 
 ## 3.8.0 [2025-06-26]
 

--- a/Makefile
+++ b/Makefile
@@ -5,26 +5,26 @@ help:
 	@awk 'BEGIN {FS = ":.*##"; printf "Usage: make \033[36m<target>\033[0m\n"} /^[a-zA-Z0-9_-]+:.*?##/ { printf "  \033[36m%-46s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 dshell: ## Start Docker Shell for Local Development
-	@docker-compose run --entrypoint=bash --rm php
+	@docker compose run --entrypoint=bash --rm php
 
 deps: ## Installs the project dependencies
-	@docker-compose run php composer install
+	@docker compose run php composer install
 
 test: start-server ## Perform unit tests
-	@docker-compose run php composer run test
+	@docker compose run php composer run test
 
 coverage: start-server ## Perform unit tests with code coverage
-	@docker-compose run php composer run test-coverage
+	@docker compose run php composer run test-coverage
 
 coverage-show: ## Show the code coverage report
 	open build/coverage-report/index.html
 
 start-server: ## Start the InfluxDB server
-	@docker-compose up -d influxdb_v2
+	@docker compose up -d influxdb_v2
 	@scripts/influxdb-onboarding.sh ||:
 
 stop-server: ## Stop the InfluxDB serve
-	@docker-compose stop influxdb_v2
+	@docker compose stop influxdb_v2
 
 release: ## Release client with version specified by VERSION property . make release VERSION=1.5.0
 	$(if $(VERSION),,$(error VERSION is not defined. Pass via "make release VERSION=1.5.0"))
@@ -40,8 +40,8 @@ release: ## Release client with version specified by VERSION property . make rel
 	git push origin master
 
 doc-generate: ## Generate documentation
-	@docker-compose run doxygen
+	@docker compose run doxygen
 
 doc-publish: ## Publish documentation as GH-Pages
 	$(MAKE) doc-generate
-	@docker-compose run doc-publish
+	@docker compose run doc-publish


### PR DESCRIPTION
## Proposed Changes

Use Docker Compose v2+ in Makefile since v1 is [not maintained anymore](https://docs.docker.com/retired/#docker-compose-v1-replaced-by-compose-v2).

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
~- [ ] A test has been added if appropriate~
- [x] `make test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
