### PR TITLE
feat(tests): add PHPStan and typehints to tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,6 +159,28 @@ jobs:
           mkdir -p tools/php-cs-fixer
           composer require --working-dir=tools/php-cs-fixer friendsofphp/php-cs-fixer:2.18.7
           tools/php-cs-fixer/vendor/bin/php-cs-fixer fix --dry-run --verbose --show-progress=estimating --using-cache=no --diff
+  phpstan:
+    docker:
+      - image: *default-php-image
+    steps:
+      - checkout
+      - restore_cache:
+          name: Restoring Composer Cache
+          keys:
+            - composer-v3-{{ checksum "composer.json" }}
+            - composer-v3-
+      - run:
+          name: Install Dependencies
+          command: composer install -n --prefer-dist
+      - save_cache:
+          name: Saving Composer Cache
+          key: composer-v3-{{ checksum "composer.lock" }}
+          paths:
+            - vendor
+          when: always
+      - run:
+          name: Run PHPStan
+          command: vendor/bin/phpstan analyse --no-progress
 
 workflows:
   version: 2
@@ -194,6 +216,7 @@ workflows:
       - tests-cURL:
           name: php-cURL-client
       - check-code-style
+      - phpstan
 
   nightly:
     when:

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,11 @@
     "phpunit/phpunit": "^8.5.27",
     "squizlabs/php_codesniffer": "~4.0",
     "guzzlehttp/guzzle": "^7.0.1",
-    "guzzlehttp/psr7": "^2.0.0"
+    "guzzlehttp/psr7": "^2.0.0",
+    "phpstan/phpstan": "^1.12.33 || ^2.2.6",
+    "phpstan/phpstan-deprecation-rules": "^1.2.1 || ^2.0.4",
+    "phpstan/phpstan-phpunit": "^1.4.2 || ^2.0.18",
+    "phpstan/phpstan-strict-rules": "^1.6.2 || ^2.0.12"
   },
   "suggest": {
     "ext-sockets": "Required for UDP writer."

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,1741 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Call to an undefined method object\:\:deleteBucketsID\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: examples/BucketManagementExample.php
+
+		-
+			message: '#^Call to an undefined method object\:\:getBuckets\(\)\.$#'
+			identifier: method.notFound
+			count: 2
+			path: examples/BucketManagementExample.php
+
+		-
+			message: '#^Call to an undefined method object\:\:postBuckets\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: examples/BucketManagementExample.php
+
+		-
+			message: '#^Cannot call method getOrgs\(\) on object\|string\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: examples/BucketManagementExample.php
+
+		-
+			message: '#^Function findMyOrg\(\) has parameter \$client with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: examples/BucketManagementExample.php
+
+		-
+			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
+			identifier: equal.notAllowed
+			count: 1
+			path: examples/BucketManagementExample.php
+
+		-
+			message: '#^Parameter \#1 \$start of method InfluxDB2\\Model\\DeletePredicateRequest\:\:setStart\(\) expects DateTime, DateTime\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: examples/DeleteDataExample.php
+
+		-
+			message: '#^Parameter \#2 \$params of method InfluxDB2\\InvokableScriptsApi\:\:invokeScript\(\) expects array\<string, object\>\|null, array\<string, string\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: examples/InvokableScripts.php
+
+		-
+			message: '#^Parameter \#2 \$params of method InfluxDB2\\InvokableScriptsApi\:\:invokeScriptStream\(\) expects array\<string, object\>\|null, array\<string, string\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: examples/InvokableScripts.php
+
+		-
+			message: '#^Call to an undefined method object\:\:postDelete\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: examples/QueryExample.php
+
+		-
+			message: '#^Parameter \#1 \$start of method InfluxDB2\\Model\\DeletePredicateRequest\:\:setStart\(\) expects DateTime, DateTime\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: examples/QueryExample.php
+
+		-
+			message: '#^Parameter \#1 \$fp of function fclose expects resource, resource\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: examples/QueryFromFileExample.php
+
+		-
+			message: '#^Parameter \#1 \$fp of function fread expects resource, resource\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: examples/QueryFromFileExample.php
+
+		-
+			message: '#^Parameter \#1 \$query of method InfluxDB2\\QueryApi\:\:query\(\) expects InfluxDB2\\Model\\Query\|string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: examples/QueryFromFileExample.php
+
+		-
+			message: '#^Parameter \#2 \$length of function fread expects int\<1, max\>, int\<0, max\>\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: examples/QueryFromFileExample.php
+
+		-
+			message: '#^Switch condition type \(int\) does not match case condition "0" \(string\)\.$#'
+			identifier: switch.type
+			count: 1
+			path: examples/QueryFromFileExample.php
+
+		-
+			message: '#^Switch condition type \(int\) does not match case condition "1" \(string\)\.$#'
+			identifier: switch.type
+			count: 1
+			path: examples/QueryFromFileExample.php
+
+		-
+			message: '#^Switch condition type \(int\) does not match case condition "2" \(string\)\.$#'
+			identifier: switch.type
+			count: 1
+			path: examples/QueryFromFileExample.php
+
+		-
+			message: '#^Switch condition type \(int\) does not match case condition "3" \(string\)\.$#'
+			identifier: switch.type
+			count: 1
+			path: examples/QueryFromFileExample.php
+
+		-
+			message: '#^Switch condition type \(int\) does not match case condition "4" \(string\)\.$#'
+			identifier: switch.type
+			count: 1
+			path: examples/QueryFromFileExample.php
+
+		-
+			message: '#^Switch condition type \(int\) does not match case condition "5" \(string\)\.$#'
+			identifier: switch.type
+			count: 1
+			path: examples/QueryFromFileExample.php
+
+		-
+			message: '#^Switch condition type \(int\) does not match case condition "6" \(string\)\.$#'
+			identifier: switch.type
+			count: 1
+			path: examples/QueryFromFileExample.php
+
+		-
+			message: '#^Function checkResult\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: examples/WriteExample.php
+
+		-
+			message: '#^Dead catch \- Exception is never thrown in the try block\.$#'
+			identifier: catch.neverThrown
+			count: 1
+			path: examples/WriteUDPExample.php
+
+		-
+			message: '#^Method InfluxDB2\\BatchItem\:\:__construct\(\) has parameter \$data with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/BatchItem.php
+
+		-
+			message: '#^Method InfluxDB2\\BatchItem\:\:__construct\(\) has parameter \$key with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/BatchItem.php
+
+		-
+			message: '#^Method InfluxDB2\\BatchItemKey\:\:__construct\(\) has parameter \$bucket with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/BatchItemKey.php
+
+		-
+			message: '#^Method InfluxDB2\\BatchItemKey\:\:__construct\(\) has parameter \$org with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/BatchItemKey.php
+
+		-
+			message: '#^Method InfluxDB2\\BatchItemKey\:\:__construct\(\) has parameter \$precision with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/BatchItemKey.php
+
+		-
+			message: '#^Call to an undefined method object\:\:getPingWithHttpInfo\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/InfluxDB2/Client.php
+
+		-
+			message: '#^Method InfluxDB2\\Client\:\:__construct\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/InfluxDB2/Client.php
+
+		-
+			message: '#^Method InfluxDB2\\Client\:\:close\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/InfluxDB2/Client.php
+
+		-
+			message: '#^Method InfluxDB2\\Client\:\:createService\(\) has parameter \$serviceClass with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/Client.php
+
+		-
+			message: '#^Method InfluxDB2\\Client\:\:createWriteApi\(\) has parameter \$pointSettings with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/InfluxDB2/Client.php
+
+		-
+			message: '#^Method InfluxDB2\\Client\:\:createWriteApi\(\) has parameter \$writeOptions with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/InfluxDB2/Client.php
+
+		-
+			message: '#^Method InfluxDB2\\Client\:\:ping\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/InfluxDB2/Client.php
+
+		-
+			message: '#^Property InfluxDB2\\Client\:\:\$autoCloseable has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/InfluxDB2/Client.php
+
+		-
+			message: '#^Property InfluxDB2\\Client\:\:\$closed has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/InfluxDB2/Client.php
+
+		-
+			message: '#^Property InfluxDB2\\Client\:\:\$options has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/InfluxDB2/Client.php
+
+		-
+			message: '#^Method InfluxDB2\\DefaultApi\:\:__construct\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/InfluxDB2/DefaultApi.php
+
+		-
+			message: '#^Method InfluxDB2\\DefaultApi\:\:check\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/InfluxDB2/DefaultApi.php
+
+		-
+			message: '#^Method InfluxDB2\\DefaultApi\:\:check\(\) has parameter \$key with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/DefaultApi.php
+
+		-
+			message: '#^Method InfluxDB2\\DefaultApi\:\:check\(\) has parameter \$value with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/DefaultApi.php
+
+		-
+			message: '#^Method InfluxDB2\\DefaultApi\:\:get\(\) has parameter \$payload with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/DefaultApi.php
+
+		-
+			message: '#^Method InfluxDB2\\DefaultApi\:\:get\(\) has parameter \$queryParams with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/DefaultApi.php
+
+		-
+			message: '#^Method InfluxDB2\\DefaultApi\:\:get\(\) has parameter \$uriPath with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/DefaultApi.php
+
+		-
+			message: '#^Method InfluxDB2\\DefaultApi\:\:log\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/InfluxDB2/DefaultApi.php
+
+		-
+			message: '#^Method InfluxDB2\\DefaultApi\:\:post\(\) has parameter \$payload with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/DefaultApi.php
+
+		-
+			message: '#^Method InfluxDB2\\DefaultApi\:\:post\(\) has parameter \$queryParams with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/DefaultApi.php
+
+		-
+			message: '#^Method InfluxDB2\\DefaultApi\:\:post\(\) has parameter \$uriPath with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/DefaultApi.php
+
+		-
+			message: '#^Method InfluxDB2\\DefaultApi\:\:request\(\) has parameter \$method with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/DefaultApi.php
+
+		-
+			message: '#^Method InfluxDB2\\DefaultApi\:\:request\(\) has parameter \$payload with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/DefaultApi.php
+
+		-
+			message: '#^Method InfluxDB2\\DefaultApi\:\:request\(\) has parameter \$queryParams with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/DefaultApi.php
+
+		-
+			message: '#^Method InfluxDB2\\DefaultApi\:\:request\(\) has parameter \$uriPath with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/DefaultApi.php
+
+		-
+			message: '#^Only booleans are allowed in a ternary operator condition, Psr\\Http\\Message\\ResponseInterface given\.$#'
+			identifier: ternary.condNotBoolean
+			count: 2
+			path: src/InfluxDB2/DefaultApi.php
+
+		-
+			message: '#^Parameter \#3 \$responseHeaders of class InfluxDB2\\ApiException constructor expects array\<string\>\|null, array\<array\<string\>\> given\.$#'
+			identifier: argument.type
+			count: 2
+			path: src/InfluxDB2/DefaultApi.php
+
+		-
+			message: '#^Property InfluxDB2\\DefaultApi\:\:\$options has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/InfluxDB2/DefaultApi.php
+
+		-
+			message: '#^Ternary operator condition is always true\.$#'
+			identifier: ternary.alwaysTrue
+			count: 2
+			path: src/InfluxDB2/DefaultApi.php
+
+		-
+			message: '#^Method InfluxDB2\\FluxColumn\:\:__construct\(\) has parameter \$dataType with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/FluxColumn.php
+
+		-
+			message: '#^Method InfluxDB2\\FluxColumn\:\:__construct\(\) has parameter \$defaultValue with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/FluxColumn.php
+
+		-
+			message: '#^Method InfluxDB2\\FluxColumn\:\:__construct\(\) has parameter \$group with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/FluxColumn.php
+
+		-
+			message: '#^Method InfluxDB2\\FluxColumn\:\:__construct\(\) has parameter \$index with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/FluxColumn.php
+
+		-
+			message: '#^Method InfluxDB2\\FluxColumn\:\:__construct\(\) has parameter \$label with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/FluxColumn.php
+
+		-
+			message: '#^Property InfluxDB2\\FluxColumn\:\:\$dataType has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/InfluxDB2/FluxColumn.php
+
+		-
+			message: '#^Property InfluxDB2\\FluxColumn\:\:\$defaultValue has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/InfluxDB2/FluxColumn.php
+
+		-
+			message: '#^Property InfluxDB2\\FluxColumn\:\:\$group has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/InfluxDB2/FluxColumn.php
+
+		-
+			message: '#^Property InfluxDB2\\FluxColumn\:\:\$index has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/InfluxDB2/FluxColumn.php
+
+		-
+			message: '#^Property InfluxDB2\\FluxColumn\:\:\$label has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/InfluxDB2/FluxColumn.php
+
+		-
+			message: '#^Call to function base64_decode\(\) requires parameter \#2 to be set\.$#'
+			identifier: function.strict
+			count: 1
+			path: src/InfluxDB2/FluxCsvParser.php
+
+		-
+			message: '#^Call to function in_array\(\) requires parameter \#3 to be set\.$#'
+			identifier: function.strict
+			count: 1
+			path: src/InfluxDB2/FluxCsvParser.php
+
+		-
+			message: '#^Call to function is_null\(\) with InfluxDB2\\FluxTable will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 1
+			path: src/InfluxDB2/FluxCsvParser.php
+
+		-
+			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
+			identifier: empty.notAllowed
+			count: 2
+			path: src/InfluxDB2/FluxCsvParser.php
+
+		-
+			message: '#^Loose comparison via "\!\=" is not allowed\.$#'
+			identifier: notEqual.notAllowed
+			count: 1
+			path: src/InfluxDB2/FluxCsvParser.php
+
+		-
+			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
+			identifier: equal.notAllowed
+			count: 25
+			path: src/InfluxDB2/FluxCsvParser.php
+
+		-
+			message: '#^Method InfluxDB2\\FluxCsvParser\:\:__construct\(\) has parameter \$response with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/FluxCsvParser.php
+
+		-
+			message: '#^Method InfluxDB2\\FluxCsvParser\:\:addColumnNamesAndTags\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/InfluxDB2/FluxCsvParser.php
+
+		-
+			message: '#^Method InfluxDB2\\FluxCsvParser\:\:addColumnNamesAndTags\(\) has parameter \$csv with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/InfluxDB2/FluxCsvParser.php
+
+		-
+			message: '#^Method InfluxDB2\\FluxCsvParser\:\:addDataTypes\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/InfluxDB2/FluxCsvParser.php
+
+		-
+			message: '#^Method InfluxDB2\\FluxCsvParser\:\:addDataTypes\(\) has parameter \$data_types with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/InfluxDB2/FluxCsvParser.php
+
+		-
+			message: '#^Method InfluxDB2\\FluxCsvParser\:\:addDefaultEmptyValues\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/InfluxDB2/FluxCsvParser.php
+
+		-
+			message: '#^Method InfluxDB2\\FluxCsvParser\:\:addDefaultEmptyValues\(\) has parameter \$defaultValues with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/FluxCsvParser.php
+
+		-
+			message: '#^Method InfluxDB2\\FluxCsvParser\:\:addGroups\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/InfluxDB2/FluxCsvParser.php
+
+		-
+			message: '#^Method InfluxDB2\\FluxCsvParser\:\:addGroups\(\) has parameter \$csv with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/FluxCsvParser.php
+
+		-
+			message: '#^Method InfluxDB2\\FluxCsvParser\:\:closeConnection\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/InfluxDB2/FluxCsvParser.php
+
+		-
+			message: '#^Method InfluxDB2\\FluxCsvParser\:\:each\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/InfluxDB2/FluxCsvParser.php
+
+		-
+			message: '#^Method InfluxDB2\\FluxCsvParser\:\:parse\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/InfluxDB2/FluxCsvParser.php
+
+		-
+			message: '#^Method InfluxDB2\\FluxCsvParser\:\:parseLine\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/InfluxDB2/FluxCsvParser.php
+
+		-
+			message: '#^Method InfluxDB2\\FluxCsvParser\:\:parseLine\(\) has parameter \$csv with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/InfluxDB2/FluxCsvParser.php
+
+		-
+			message: '#^Method InfluxDB2\\FluxCsvParser\:\:parseRecord\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/InfluxDB2/FluxCsvParser.php
+
+		-
+			message: '#^Method InfluxDB2\\FluxCsvParser\:\:parseRecord\(\) has parameter \$csv with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/InfluxDB2/FluxCsvParser.php
+
+		-
+			message: '#^Method InfluxDB2\\FluxCsvParser\:\:parseValues\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/InfluxDB2/FluxCsvParser.php
+
+		-
+			message: '#^Method InfluxDB2\\FluxCsvParser\:\:parseValues\(\) has parameter \$csv with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/InfluxDB2/FluxCsvParser.php
+
+		-
+			message: '#^Method InfluxDB2\\FluxCsvParser\:\:stringToStream\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/InfluxDB2/FluxCsvParser.php
+
+		-
+			message: '#^Method InfluxDB2\\FluxCsvParser\:\:toValue\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/InfluxDB2/FluxCsvParser.php
+
+		-
+			message: '#^Method InfluxDB2\\FluxCsvParser\:\:toValue\(\) has parameter \$strVal with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/FluxCsvParser.php
+
+		-
+			message: '#^Parameter \#1 \$fp of function fwrite expects resource, resource\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/InfluxDB2/FluxCsvParser.php
+
+		-
+			message: '#^Parameter \#1 \$fp of function rewind expects resource, resource\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/InfluxDB2/FluxCsvParser.php
+
+		-
+			message: '#^Parameter \#2 \$code of class InfluxDB2\\FluxQueryError constructor expects int, int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/InfluxDB2/FluxCsvParser.php
+
+		-
+			message: '#^Property InfluxDB2\\FluxCsvParser\:\:\$closed has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/InfluxDB2/FluxCsvParser.php
+
+		-
+			message: '#^Property InfluxDB2\\FluxCsvParser\:\:\$groups has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/InfluxDB2/FluxCsvParser.php
+
+		-
+			message: '#^Property InfluxDB2\\FluxCsvParser\:\:\$parsingStateError has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/InfluxDB2/FluxCsvParser.php
+
+		-
+			message: '#^Property InfluxDB2\\FluxCsvParser\:\:\$resource has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/InfluxDB2/FluxCsvParser.php
+
+		-
+			message: '#^Property InfluxDB2\\FluxCsvParser\:\:\$response has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/InfluxDB2/FluxCsvParser.php
+
+		-
+			message: '#^Property InfluxDB2\\FluxCsvParser\:\:\$responseMode has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/InfluxDB2/FluxCsvParser.php
+
+		-
+			message: '#^Property InfluxDB2\\FluxCsvParser\:\:\$startNewTable has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/InfluxDB2/FluxCsvParser.php
+
+		-
+			message: '#^Property InfluxDB2\\FluxCsvParser\:\:\$stream has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/InfluxDB2/FluxCsvParser.php
+
+		-
+			message: '#^Property InfluxDB2\\FluxCsvParser\:\:\$tableId has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/InfluxDB2/FluxCsvParser.php
+
+		-
+			message: '#^Property InfluxDB2\\FluxCsvParser\:\:\$tableIndex has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/InfluxDB2/FluxCsvParser.php
+
+		-
+			message: '#^Property InfluxDB2\\FluxCsvParser\:\:\$tables has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/InfluxDB2/FluxCsvParser.php
+
+		-
+			message: '#^Result of && is always false\.$#'
+			identifier: booleanAnd.alwaysFalse
+			count: 1
+			path: src/InfluxDB2/FluxCsvParser.php
+
+		-
+			message: '#^Class InfluxDB2\\FluxRecord implements generic interface ArrayAccess but does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: src/InfluxDB2/FluxRecord.php
+
+		-
+			message: '#^Method InfluxDB2\\FluxRecord\:\:__construct\(\) has parameter \$row with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/FluxRecord.php
+
+		-
+			message: '#^Method InfluxDB2\\FluxRecord\:\:__construct\(\) has parameter \$table with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/FluxRecord.php
+
+		-
+			message: '#^Method InfluxDB2\\FluxRecord\:\:__construct\(\) has parameter \$values with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/FluxRecord.php
+
+		-
+			message: '#^PHPDoc tag @return with type mixed is not subtype of native type string\.$#'
+			identifier: return.phpDocType
+			count: 1
+			path: src/InfluxDB2/FluxRecord.php
+
+		-
+			message: '#^Property InfluxDB2\\FluxRecord\:\:\$row has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/InfluxDB2/FluxRecord.php
+
+		-
+			message: '#^Property InfluxDB2\\FluxRecord\:\:\$table has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/InfluxDB2/FluxRecord.php
+
+		-
+			message: '#^Property InfluxDB2\\FluxRecord\:\:\$values has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/InfluxDB2/FluxRecord.php
+
+		-
+			message: '#^Method InfluxDB2\\FluxTable\:\:getGroupKey\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/InfluxDB2/FluxTable.php
+
+		-
+			message: '#^Method InfluxDB2\\HealthApi\:\:__construct\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/InfluxDB2/HealthApi.php
+
+		-
+			message: '#^Method InfluxDB2\\HealthApi\:\:health\(\) should return InfluxDB2\\Model\\HealthCheck but returns array\|object\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: src/InfluxDB2/HealthApi.php
+
+		-
+			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
+			identifier: equal.notAllowed
+			count: 1
+			path: src/InfluxDB2/Internal/DebugHttpPlugin.php
+
+		-
+			message: '#^Method InfluxDB2\\Internal\\DebugHttpPlugin\:\:__construct\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/InfluxDB2/Internal/DebugHttpPlugin.php
+
+		-
+			message: '#^Property InfluxDB2\\Internal\\DebugHttpPlugin\:\:\$options has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/InfluxDB2/Internal/DebugHttpPlugin.php
+
+		-
+			message: '#^Method InfluxDB2\\InvokableScriptsApi\:\:__construct\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/InfluxDB2/InvokableScriptsApi.php
+
+		-
+			message: '#^Method InfluxDB2\\InvokableScriptsApi\:\:invokeScriptRaw\(\) has parameter \$params with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/InfluxDB2/InvokableScriptsApi.php
+
+		-
+			message: '#^Property InfluxDB2\\InvokableScriptsApi\:\:\$service has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/InfluxDB2/InvokableScriptsApi.php
+
+		-
+			message: '#^Call to function is_double\(\) with int will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 1
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^Call to function is_float\(\) with int will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 1
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^Call to function is_long\(\) with mixed will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 1
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^Instanceof between int and DateTimeInterface will always evaluate to false\.$#'
+			identifier: instanceof.alwaysFalse
+			count: 1
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
+			identifier: equal.notAllowed
+			count: 2
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^Method InfluxDB2\\Point\:\:__construct\(\) has parameter \$fields with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^Method InfluxDB2\\Point\:\:__construct\(\) has parameter \$name with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^Method InfluxDB2\\Point\:\:__construct\(\) has parameter \$precision with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^Method InfluxDB2\\Point\:\:__construct\(\) has parameter \$tags with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^Method InfluxDB2\\Point\:\:__construct\(\) has parameter \$time with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^Method InfluxDB2\\Point\:\:addField\(\) has parameter \$key with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^Method InfluxDB2\\Point\:\:addField\(\) has parameter \$value with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^Method InfluxDB2\\Point\:\:addTag\(\) has parameter \$key with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^Method InfluxDB2\\Point\:\:appendFields\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^Method InfluxDB2\\Point\:\:appendTags\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^Method InfluxDB2\\Point\:\:appendTime\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^Method InfluxDB2\\Point\:\:escapeKey\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^Method InfluxDB2\\Point\:\:escapeKey\(\) has parameter \$escapeEqual with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^Method InfluxDB2\\Point\:\:escapeKey\(\) has parameter \$key with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^Method InfluxDB2\\Point\:\:escapeValue\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^Method InfluxDB2\\Point\:\:escapeValue\(\) has parameter \$value with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^Method InfluxDB2\\Point\:\:fromArray\(\) has parameter \$data with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^Method InfluxDB2\\Point\:\:getPrecision\(\) should return string\|null but returns InfluxDB2\\Model\\WritePrecision\.$#'
+			identifier: return.type
+			count: 1
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^Method InfluxDB2\\Point\:\:isNullOrEmptyString\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^Method InfluxDB2\\Point\:\:isNullOrEmptyString\(\) has parameter \$str with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^Method InfluxDB2\\Point\:\:measurement\(\) has parameter \$name with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^Method InfluxDB2\\Point\:\:time\(\) has parameter \$precision with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^Method InfluxDB2\\Point\:\:time\(\) has parameter \$time with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^Method InfluxDB2\\Point\:\:toLineProtocol\(\) should return string but returns null\.$#'
+			identifier: return.type
+			count: 1
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^PHPDoc tag @param for parameter \$value with type object\|string\|null is not subtype of native type string\|null\.$#'
+			identifier: parameter.phpDocType
+			count: 1
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^PHPDoc tag @param has invalid value \(\[Array\] data\)\: Unexpected token "\]", expected ''\('' at offset 78 on line 3$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^PHPDoc tag @param has invalid value \(\[Array\] fields the fields for the point\)\: Unexpected token "\]", expected ''\('' at offset 206 on line 5$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^PHPDoc tag @param has invalid value \(\[Array\] tags the tag set for the point\)\: Unexpected token "\]", expected ''\('' at offset 153 on line 4$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^PHPDoc tag @param has invalid value \(\[Integer\] time the timestamp for the point\)\: Unexpected token "\[", expected type at offset 254 on line 6$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^PHPDoc tag @param has invalid value \(\[Object\] key the tag name\)\: Unexpected token "\[", expected type at offset 67 on line 3$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^PHPDoc tag @param has invalid value \(\[Object\] key the tag name\)\: Unexpected token "\[", expected type at offset 69 on line 3$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^PHPDoc tag @param has invalid value \(\[Object\] time the timestamp\)\: Unexpected token "\[", expected type at offset 62 on line 3$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^PHPDoc tag @param has invalid value \(\[Object\] value the tag value\)\: Unexpected token "\[", expected type at offset 109 on line 4$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^PHPDoc tag @param has invalid value \(\[String\] name the measurement name for the point\.\)\: Unexpected token "\[", expected type at offset 83 on line 3$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^PHPDoc tag @param has invalid value \(\[WritePrecision\] precision the precision for the unix timestamps within the body line\-protocol\)\: Unexpected token "\[", expected type at offset 311 on line 7$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^PHPDoc tag @param has invalid value \(\[WritePrecision\] precision the timestamp precision\)\: Unexpected token "\[", expected type at offset 104 on line 4$#'
+			identifier: phpDoc.parseError
+			count: 1
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^PHPDoc tag @return with type InfluxDB2\\Model\\WritePrecision is incompatible with native type string\|null\.$#'
+			identifier: return.phpDocType
+			count: 1
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^Property InfluxDB2\\Point\:\:\$fields type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^Property InfluxDB2\\Point\:\:\$tags type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^Property InfluxDB2\\Point\:\:\$time \(int\) in isset\(\) is not nullable\.$#'
+			identifier: isset.property
+			count: 1
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^Result of \|\| is always false\.$#'
+			identifier: booleanOr.alwaysFalse
+			count: 1
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^Switch condition type \(InfluxDB2\\Model\\WritePrecision\) does not match case condition \\InfluxDB2\\Model\\WritePrecision\:\:MS \(string\)\.$#'
+			identifier: switch.type
+			count: 1
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^Switch condition type \(InfluxDB2\\Model\\WritePrecision\) does not match case condition \\InfluxDB2\\Model\\WritePrecision\:\:S \(string\)\.$#'
+			identifier: switch.type
+			count: 1
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^Switch condition type \(InfluxDB2\\Model\\WritePrecision\) does not match case condition \\InfluxDB2\\Model\\WritePrecision\:\:US \(string\)\.$#'
+			identifier: switch.type
+			count: 1
+			path: src/InfluxDB2/Point.php
+
+		-
+			message: '#^Method InfluxDB2\\PointSettings\:\:__construct\(\) has parameter \$defaultTags with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/InfluxDB2/PointSettings.php
+
+		-
+			message: '#^Method InfluxDB2\\PointSettings\:\:addDefaultTag\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/InfluxDB2/PointSettings.php
+
+		-
+			message: '#^Method InfluxDB2\\PointSettings\:\:getDefaultTags\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/InfluxDB2/PointSettings.php
+
+		-
+			message: '#^Method InfluxDB2\\PointSettings\:\:getValue\(\) should return string but returns string\|false\.$#'
+			identifier: return.type
+			count: 1
+			path: src/InfluxDB2/PointSettings.php
+
+		-
+			message: '#^Property InfluxDB2\\PointSettings\:\:\$defaultTags has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/InfluxDB2/PointSettings.php
+
+		-
+			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
+			identifier: equal.notAllowed
+			count: 4
+			path: src/InfluxDB2/QueryApi.php
+
+		-
+			message: '#^Method InfluxDB2\\QueryApi\:\:__construct\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/InfluxDB2/QueryApi.php
+
+		-
+			message: '#^Method InfluxDB2\\QueryApi\:\:generatePayload\(\) has parameter \$dialect with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/QueryApi.php
+
+		-
+			message: '#^Method InfluxDB2\\QueryApi\:\:generatePayload\(\) has parameter \$query with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/QueryApi.php
+
+		-
+			message: '#^Method InfluxDB2\\QueryApi\:\:postQuery\(\) has parameter \$dialect with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/QueryApi.php
+
+		-
+			message: '#^Method InfluxDB2\\QueryApi\:\:postQuery\(\) has parameter \$org with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/QueryApi.php
+
+		-
+			message: '#^Method InfluxDB2\\QueryApi\:\:postQuery\(\) has parameter \$query with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/QueryApi.php
+
+		-
+			message: '#^Property InfluxDB2\\QueryApi\:\:\$DEFAULT_DIALECT has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/InfluxDB2/QueryApi.php
+
+		-
+			message: '#^Short ternary operator is not allowed\. Use null coalesce operator if applicable or consider using long ternary\.$#'
+			identifier: ternary.shortNotAllowed
+			count: 4
+			path: src/InfluxDB2/QueryApi.php
+
+		-
+			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
+			identifier: empty.notAllowed
+			count: 4
+			path: src/InfluxDB2/UdpWriter.php
+
+		-
+			message: '#^Method InfluxDB2\\UdpWriter\:\:__construct\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/InfluxDB2/UdpWriter.php
+
+		-
+			message: '#^Method InfluxDB2\\UdpWriter\:\:close\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/InfluxDB2/UdpWriter.php
+
+		-
+			message: '#^Method InfluxDB2\\UdpWriter\:\:write\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/InfluxDB2/UdpWriter.php
+
+		-
+			message: '#^Method InfluxDB2\\UdpWriter\:\:write\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/InfluxDB2/UdpWriter.php
+
+		-
+			message: '#^Only booleans are allowed in an if condition, resource\|false given\.$#'
+			identifier: if.condNotBoolean
+			count: 1
+			path: src/InfluxDB2/UdpWriter.php
+
+		-
+			message: '#^Property InfluxDB2\\UdpWriter\:\:\$options has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/InfluxDB2/UdpWriter.php
+
+		-
+			message: '#^Property InfluxDB2\\UdpWriter\:\:\$socket \(resource\) does not accept null\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: src/InfluxDB2/UdpWriter.php
+
+		-
+			message: '#^Property InfluxDB2\\UdpWriter\:\:\$socket \(resource\) does not accept resource\|false\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: src/InfluxDB2/UdpWriter.php
+
+		-
+			message: '#^Property InfluxDB2\\UdpWriter\:\:\$socket \(resource\) in empty\(\) is not falsy\.$#'
+			identifier: empty.property
+			count: 1
+			path: src/InfluxDB2/UdpWriter.php
+
+		-
+			message: '#^Property InfluxDB2\\UdpWriter\:\:\$socket \(resource\) in isset\(\) is not nullable\.$#'
+			identifier: isset.property
+			count: 1
+			path: src/InfluxDB2/UdpWriter.php
+
+		-
+			message: '#^Call to function array_search\(\) requires parameter \#3 to be set\.$#'
+			identifier: function.strict
+			count: 1
+			path: src/InfluxDB2/Worker.php
+
+		-
+			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
+			identifier: empty.notAllowed
+			count: 1
+			path: src/InfluxDB2/Worker.php
+
+		-
+			message: '#^Loose comparison via "\!\=" is not allowed\.$#'
+			identifier: notEqual.notAllowed
+			count: 2
+			path: src/InfluxDB2/Worker.php
+
+		-
+			message: '#^Method InfluxDB2\\Worker\:\:__construct\(\) has parameter \$client with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/Worker.php
+
+		-
+			message: '#^Method InfluxDB2\\Worker\:\:checkBackgroundQueue\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/InfluxDB2/Worker.php
+
+		-
+			message: '#^Method InfluxDB2\\Worker\:\:existsKey\(\) has parameter \$data with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/Worker.php
+
+		-
+			message: '#^Method InfluxDB2\\Worker\:\:existsKey\(\) has parameter \$key with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/Worker.php
+
+		-
+			message: '#^Method InfluxDB2\\Worker\:\:existsKey\(\) should return int\|null but returns int\|string\|false\.$#'
+			identifier: return.type
+			count: 1
+			path: src/InfluxDB2/Worker.php
+
+		-
+			message: '#^Method InfluxDB2\\Worker\:\:flush\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/InfluxDB2/Worker.php
+
+		-
+			message: '#^Method InfluxDB2\\Worker\:\:push\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/InfluxDB2/Worker.php
+
+		-
+			message: '#^Method InfluxDB2\\Worker\:\:push\(\) has parameter \$payload with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/Worker.php
+
+		-
+			message: '#^Method InfluxDB2\\Worker\:\:write\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/InfluxDB2/Worker.php
+
+		-
+			message: '#^Method InfluxDB2\\Worker\:\:write\(\) has parameter \$data with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/Worker.php
+
+		-
+			message: '#^Property InfluxDB2\\Worker\:\:\$queue has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/InfluxDB2/Worker.php
+
+		-
+			message: '#^Property InfluxDB2\\Worker\:\:\$writeOptions has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/InfluxDB2/Worker.php
+
+		-
+			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
+			identifier: equal.notAllowed
+			count: 2
+			path: src/InfluxDB2/WriteApi.php
+
+		-
+			message: '#^Method InfluxDB2\\WriteApi\:\:__construct\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/InfluxDB2/WriteApi.php
+
+		-
+			message: '#^Method InfluxDB2\\WriteApi\:\:__construct\(\) has parameter \$pointSettings with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/InfluxDB2/WriteApi.php
+
+		-
+			message: '#^Method InfluxDB2\\WriteApi\:\:__construct\(\) has parameter \$writeOptions with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/InfluxDB2/WriteApi.php
+
+		-
+			message: '#^Method InfluxDB2\\WriteApi\:\:addDefaultTags\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/InfluxDB2/WriteApi.php
+
+		-
+			message: '#^Method InfluxDB2\\WriteApi\:\:addDefaultTags\(\) has parameter \$data with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/WriteApi.php
+
+		-
+			message: '#^Method InfluxDB2\\WriteApi\:\:close\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/InfluxDB2/WriteApi.php
+
+		-
+			message: '#^Method InfluxDB2\\WriteApi\:\:write\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/InfluxDB2/WriteApi.php
+
+		-
+			message: '#^Method InfluxDB2\\WriteApi\:\:write\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/InfluxDB2/WriteApi.php
+
+		-
+			message: '#^Method InfluxDB2\\WriteApi\:\:writeRaw\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/InfluxDB2/WriteApi.php
+
+		-
+			message: '#^Parameter \#1 \$data of method InfluxDB2\\WriteApi\:\:writeRaw\(\) expects string, InfluxDB2\\BatchItem\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/InfluxDB2/WriteApi.php
+
+		-
+			message: '#^Parameter \#1 \$key of method InfluxDB2\\PointSettings\:\:addDefaultTag\(\) expects string, int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/InfluxDB2/WriteApi.php
+
+		-
+			message: '#^Property InfluxDB2\\WriteApi\:\:\$closed has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/InfluxDB2/WriteApi.php
+
+		-
+			message: '#^Property InfluxDB2\\WriteApi\:\:\$pointSettings has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/InfluxDB2/WriteApi.php
+
+		-
+			message: '#^Property InfluxDB2\\WriteApi\:\:\$worker \(InfluxDB2\\Worker\) in isset\(\) is not nullable\.$#'
+			identifier: isset.property
+			count: 2
+			path: src/InfluxDB2/WriteApi.php
+
+		-
+			message: '#^Property InfluxDB2\\WriteApi\:\:\$writeOptions has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/InfluxDB2/WriteApi.php
+
+		-
+			message: '#^Short ternary operator is not allowed\. Use null coalesce operator if applicable or consider using long ternary\.$#'
+			identifier: ternary.shortNotAllowed
+			count: 2
+			path: src/InfluxDB2/WriteApi.php
+
+		-
+			message: '#^Ternary operator condition is always true\.$#'
+			identifier: ternary.alwaysTrue
+			count: 2
+			path: src/InfluxDB2/WriteApi.php
+
+		-
+			message: '#^Method InfluxDB2\\WriteOptions\:\:__construct\(\) has parameter \$writeOptions with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/InfluxDB2/WriteOptions.php
+
+		-
+			message: '#^Property InfluxDB2\\WriteOptions\:\:\$batchSize has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/InfluxDB2/WriteOptions.php
+
+		-
+			message: '#^Property InfluxDB2\\WriteOptions\:\:\$exponentialBase has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/InfluxDB2/WriteOptions.php
+
+		-
+			message: '#^Property InfluxDB2\\WriteOptions\:\:\$jitterInterval has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/InfluxDB2/WriteOptions.php
+
+		-
+			message: '#^Property InfluxDB2\\WriteOptions\:\:\$maxRetries has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/InfluxDB2/WriteOptions.php
+
+		-
+			message: '#^Property InfluxDB2\\WriteOptions\:\:\$maxRetryDelay has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/InfluxDB2/WriteOptions.php
+
+		-
+			message: '#^Property InfluxDB2\\WriteOptions\:\:\$maxRetryTime has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/InfluxDB2/WriteOptions.php
+
+		-
+			message: '#^Property InfluxDB2\\WriteOptions\:\:\$retryInterval has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/InfluxDB2/WriteOptions.php
+
+		-
+			message: '#^Property InfluxDB2\\WriteOptions\:\:\$writeType has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/InfluxDB2/WriteOptions.php
+
+		-
+			message: '#^Binary operation "\." between InfluxDB2\\BatchItem\|string\|null and "\\n" results in an error\.$#'
+			identifier: binaryOp.invalid
+			count: 1
+			path: src/InfluxDB2/WritePayloadSerializer.php
+
+		-
+			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
+			identifier: empty.notAllowed
+			count: 1
+			path: src/InfluxDB2/WritePayloadSerializer.php
+
+		-
+			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
+			identifier: equal.notAllowed
+			count: 2
+			path: src/InfluxDB2/WritePayloadSerializer.php
+
+		-
+			message: '#^Method InfluxDB2\\WritePayloadSerializer\:\:generatePayload\(\) has parameter \$data with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/WritePayloadSerializer.php
+
+		-
+			message: '#^Variable \$payload in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.variable
+			count: 1
+			path: src/InfluxDB2/WritePayloadSerializer.php
+
+		-
+			message: '#^Loose comparison via "\!\=" is not allowed\.$#'
+			identifier: notEqual.notAllowed
+			count: 1
+			path: src/InfluxDB2/WriteRetry.php
+
+		-
+			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
+			identifier: equal.notAllowed
+			count: 1
+			path: src/InfluxDB2/WriteRetry.php
+
+		-
+			message: '#^Method InfluxDB2\\WriteRetry\:\:__construct\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/InfluxDB2/WriteRetry.php
+
+		-
+			message: '#^Method InfluxDB2\\WriteRetry\:\:getBackoffTime\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/InfluxDB2/WriteRetry.php
+
+		-
+			message: '#^Method InfluxDB2\\WriteRetry\:\:retry\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/InfluxDB2/WriteRetry.php
+
+		-
+			message: '#^Method InfluxDB2\\WriteRetry\:\:retry\(\) has parameter \$attempts with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/WriteRetry.php
+
+		-
+			message: '#^Method InfluxDB2\\WriteRetry\:\:retry\(\) has parameter \$callable with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: src/InfluxDB2/WriteRetry.php
+
+		-
+			message: '#^Property InfluxDB2\\WriteRetry\:\:\$exponentialBase has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/InfluxDB2/WriteRetry.php
+
+		-
+			message: '#^Property InfluxDB2\\WriteRetry\:\:\$jitterInterval has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/InfluxDB2/WriteRetry.php
+
+		-
+			message: '#^Property InfluxDB2\\WriteRetry\:\:\$maxRetries has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/InfluxDB2/WriteRetry.php
+
+		-
+			message: '#^Property InfluxDB2\\WriteRetry\:\:\$maxRetryDelay has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/InfluxDB2/WriteRetry.php
+
+		-
+			message: '#^Property InfluxDB2\\WriteRetry\:\:\$maxRetryTime has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/InfluxDB2/WriteRetry.php
+
+		-
+			message: '#^Property InfluxDB2\\WriteRetry\:\:\$options type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/InfluxDB2/WriteRetry.php
+
+		-
+			message: '#^Property InfluxDB2\\WriteRetry\:\:\$retryInterval has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/InfluxDB2/WriteRetry.php
+
+		-
+			message: '#^Property InfluxDB2\\WriteRetry\:\:\$retryTimout has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/InfluxDB2/WriteRetry.php
+
+		-
+			message: '#^Method InfluxDB2\\Writer\:\:write\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: src/InfluxDB2/Writer.php
+
+		-
+			message: '#^Method InfluxDB2\\Writer\:\:write\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/InfluxDB2/Writer.php
+
+		-
+			message: '#^Property InfluxDB2Test\\BasicTest\:\:\$requests \(array\<int, array\{request\: GuzzleHttp\\Psr7\\Request, response\: GuzzleHttp\\Psr7\\Response, error\: mixed, options\: array\<mixed\>\}\>\) does not accept array\|ArrayAccess\<int, array\>\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: tests/BasicTest.php
+
+		-
+			message: '#^Offset ''uri'' might not exist on array\{timed_out\: bool, blocked\: bool, eof\: bool, unread_bytes\: int, stream_type\: string, wrapper_type\: string, wrapper_data\: mixed, mode\: string, \.\.\.\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: tests/ClientTest.php
+
+		-
+			message: '#^Parameter \#2 \$haystack of static method PHPUnit\\Framework\\Assert\:\:assertStringContainsString\(\) expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/ClientTest.php
+
+		-
+			message: '#^Call to an undefined method object\:\:getConfig\(\)\.$#'
+			identifier: method.notFound
+			count: 2
+			path: tests/DefaultApiTest.php
+
+		-
+			message: '#^Method InfluxDB2Test\\FluxCsvParserTest\:\:assertColumns\(\) has parameter \$columnHeaders with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/FluxCsvParserTest.php
+
+		-
+			message: '#^Method InfluxDB2Test\\FluxCsvParserTest\:\:assertColumns\(\) has parameter \$values with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/FluxCsvParserTest.php
+
+		-
+			message: '#^Method InfluxDB2Test\\FluxCsvParserTest\:\:assertMultipleRecords\(\) has parameter \$tables with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/FluxCsvParserTest.php
+
+		-
+			message: '#^Call to an undefined method object\:\:getBuckets\(\)\.$#'
+			identifier: method.notFound
+			count: 2
+			path: tests/ITBucketServiceTest.php
+
+		-
+			message: '#^Call to an undefined method object\:\:getHealth\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: tests/ITBucketServiceTest.php
+
+		-
+			message: '#^Call to an undefined method object\:\:getId\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: tests/ITBucketServiceTest.php
+
+		-
+			message: '#^Call to an undefined method object\:\:getName\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: tests/ITBucketServiceTest.php
+
+		-
+			message: '#^Parameter object of print cannot be converted to string\.$#'
+			identifier: print.nonString
+			count: 1
+			path: tests/ITBucketServiceTest.php
+
+		-
+			message: '#^Call to an undefined method object\:\:getName\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: tests/ITTaskServiceTest.php
+
+		-
+			message: '#^Cannot call method getUsers\(\) on InfluxDB2\\Model\\Error\|InfluxDB2\\Model\\Users\|string\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: tests/ITUsersServiceTest.php
+
+		-
+			message: '#^Cannot call method getOrgs\(\) on object\|string\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: tests/IntegrationBaseTestCase.php
+
+		-
+			message: '#^Offset ''org'' might not exist on array\{url\: string, token\: string, bucket\?\: string, org\?\: string, precision\?\: ''ms''\|''ns''\|''s''\|''us'', allow_redirects\?\: bool, debug\?\: bool, logFile\?\: string, \.\.\.\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 1
+			path: tests/IntegrationBaseTestCase.php
+
+		-
+			message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertNotNull\(\) with InfluxDB2\\InvokableScriptsApi will always evaluate to true\.$#'
+			identifier: staticMethod.alreadyNarrowedType
+			count: 1
+			path: tests/InvokableScriptsApiTest.php
+
+		-
+			message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertNull\(\) with string will always evaluate to false\.$#'
+			identifier: staticMethod.impossibleType
+			count: 1
+			path: tests/PointTest.php
+
+		-
+			message: '#^Parameter \#2 \$value of method InfluxDB2\\Point\:\:addTag\(\) expects string\|null, int given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/PointTest.php
+
+		-
+			message: '#^Parameter \#1 \$query of method InfluxDB2\\QueryApi\:\:queryStream\(\) expects InfluxDB2\\Model\\Query\|string, null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/QueryApiStreamTest.php
+
+		-
+			message: '#^Parameter \#1 \$query of method InfluxDB2\\QueryApi\:\:query\(\) expects InfluxDB2\\Model\\Query\|string, null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/QueryApiTest.php
+
+		-
+			message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) with ''Psr\\\\Http\\\\Message\\\\RequestInterface'' and null will always evaluate to false\.$#'
+			identifier: staticMethod.impossibleType
+			count: 1
+			path: tests/WriteApiBatchingTest.php
+
+		-
+			message: '#^Parameter \#2 \$haystack of static method PHPUnit\\Framework\\Assert\:\:assertStringContainsString\(\) expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/WriteApiBatchingTest.php
+
+		-
+			message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertNotNull\(\) with InfluxDB2\\WriteApi will always evaluate to true\.$#'
+			identifier: staticMethod.alreadyNarrowedType
+			count: 1
+			path: tests/WriteApiIntegrationTest.php
+
+		-
+			message: '#^Parameter \#1 \$glue of function implode expects array, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/WriteApiTest.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,30 @@
+includes:
+    - vendor/phpstan/phpstan-deprecation-rules/rules.neon
+    - vendor/phpstan/phpstan-phpunit/extension.neon
+    - vendor/phpstan/phpstan-phpunit/rules.neon
+    - vendor/phpstan/phpstan-strict-rules/rules.neon
+
+parameters:
+    level: 6
+    excludePaths:
+        # Exclude generated files from analysis
+        analyse:
+            - src/InfluxDB2/ApiException.php
+            - src/InfluxDB2/Configuration.php
+            - src/InfluxDB2/HeaderSelector.php
+            - src/InfluxDB2/ObjectSerializer.php
+            - src/InfluxDB2/Model
+            - src/InfluxDB2/Service
+    paths:
+        - examples
+        - src
+        - tests
+    phpVersion: 70400
+    ignoreErrors:
+        -
+            message: '''
+                #^Call to deprecated method health\(\) of class InfluxDB2\\Client:
+                Use `ping\(\)` instead$#
+            '''
+            path: tests/ClientTest.php
+            count: 2

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,9 +3,10 @@ includes:
     - vendor/phpstan/phpstan-phpunit/extension.neon
     - vendor/phpstan/phpstan-phpunit/rules.neon
     - vendor/phpstan/phpstan-strict-rules/rules.neon
+    - phpstan-baseline.neon
 
 parameters:
-    level: 6
+    level: 7
     excludePaths:
         # Exclude generated files from analysis
         analyse:

--- a/tests/BasicTest.php
+++ b/tests/BasicTest.php
@@ -5,10 +5,13 @@ namespace InfluxDB2Test;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
 use InfluxDB2\Client;
 use InfluxDB2\Model\WritePrecision;
 use InfluxDB2\QueryApi;
 use InfluxDB2\WriteApi;
+use InfluxDB2\WriteType;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -25,7 +28,7 @@ abstract class BasicTest extends TestCase
     protected $queryApi;
     /** @var MockHandler */
     protected $mockHandler;
-    /** @var array */
+    /** @var array<int, array{request: Request, response: Response, error: mixed, options: array<mixed>}> */
     protected $requests;
 
     /**
@@ -33,7 +36,7 @@ abstract class BasicTest extends TestCase
      * @param string $url
      * @param string $logFile default log file
      */
-    public function setUp($url = "http://localhost:8086", $logFile = "php://output"): void
+    public function setUp(string $url = "http://localhost:8086", string $logFile = "php://output"): void
     {
         $this->client = new Client([
             "url" => $url,
@@ -68,6 +71,18 @@ abstract class BasicTest extends TestCase
         $this->client->close();
     }
 
+    /**
+     * @return array{
+     *     writeType?: WriteType::BATCHING|WriteType::SYNCHRONOUS,
+     *     batchSize?: int,
+     *     retryInterval?: int,
+     *     maxRetries?: int,
+     *     maxRetryDelay?: int,
+     *     maxRetryTime?: int,
+     *     exponentialBase?: int,
+     *     jitterInterval?: int,
+     * }|null
+     */
     protected function getWriteOptions(): ?array
     {
         return null;

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -12,16 +12,16 @@ require_once('IntegrationBaseTestCase.php');
  */
 class ClientTest extends IntegrationBaseTestCase
 {
-    public function test_health()
+    public function test_health(): void
     {
         $health = $this->client->health();
 
-        $this->assertEquals('ready for queries and writes', $health->getMessage());
-        $this->assertEquals('influxdb', $health->getName());
-        $this->assertEquals('pass', $health->getStatus());
+        self::assertEquals('ready for queries and writes', $health->getMessage());
+        self::assertEquals('influxdb', $health->getName());
+        self::assertEquals('pass', $health->getStatus());
     }
 
-    public function test_health_not_running()
+    public function test_health_not_running(): void
     {
         $this->client->close();
         $this->client = new Client([
@@ -31,20 +31,20 @@ class ClientTest extends IntegrationBaseTestCase
 
         $health = $this->client->health();
 
-        $this->assertStringContainsString('Failed to connect to localhost port 8099', $health->getMessage());
-        $this->assertEquals('influxdb', $health->getName());
-        $this->assertEquals('fail', $health->getStatus());
+        self::assertStringContainsString('Failed to connect to localhost port 8099', $health->getMessage());
+        self::assertEquals('influxdb', $health->getName());
+        self::assertEquals('fail', $health->getStatus());
     }
 
-    public function test_ping()
+    public function test_ping(): void
     {
         $ping = $this->client->ping();
 
-        $this->assertArrayHasKey('X-Influxdb-Build', $ping);
-        $this->assertArrayHasKey('X-Influxdb-Version', $ping);
+        self::assertArrayHasKey('X-Influxdb-Build', $ping);
+        self::assertArrayHasKey('X-Influxdb-Version', $ping);
     }
 
-    public function test_ping_not_running()
+    public function test_ping_not_running(): void
     {
         $this->client->close();
         $this->client = new Client([
@@ -58,7 +58,7 @@ class ClientTest extends IntegrationBaseTestCase
         $this->client->ping();
     }
 
-    public function test_debug()
+    public function test_debug(): void
     {
         $logFilePath = stream_get_meta_data(tmpfile())['uri'];
         $this->client->close();
@@ -70,9 +70,9 @@ class ClientTest extends IntegrationBaseTestCase
         ]);
 
         $tables = $this->client->createQueryApi()->query("buckets()", "my-org");
-        $this->assertCount(1, $tables);
+        self::assertCount(1, $tables);
 
-        $this->assertStringContainsString('Authorization: ***', file_get_contents($logFilePath));
+        self::assertStringContainsString('Authorization: ***', file_get_contents($logFilePath));
         unlink($logFilePath);
     }
 }

--- a/tests/DefaultApiTest.php
+++ b/tests/DefaultApiTest.php
@@ -14,27 +14,27 @@ require_once('BasicTest.php');
 
 class DefaultApiTest extends BasicTest
 {
-    public function testUserAgent()
+    public function testUserAgent(): void
     {
         $this->mockHandler->append(new Response(204));
         $this->writeApi->write('h2o,location=west value=33i 15');
 
         $request = $this->mockHandler->getLastRequest();
 
-        $this->assertStringStartsWith(
+        self::assertStringStartsWith(
             'influxdb-client-php/',
             strval($request->getHeader("User-Agent")[0])
         );
     }
 
-    public function testTrailingSlashInUrl()
+    public function testTrailingSlashInUrl(): void
     {
         $this->mockHandler->append(new Response(204));
         $this->writeApi->write('h2o,location=west value=33i 15');
 
         $request = $this->mockHandler->getLastRequest();
 
-        $this->assertEquals('http://localhost:8086/api/v2/write?org=my-org&bucket=my-bucket&precision=ns', strval($request->getUri()));
+        self::assertEquals('http://localhost:8086/api/v2/write?org=my-org&bucket=my-bucket&precision=ns', strval($request->getUri()));
 
         $this->tearDown();
         $this->setUp("http://localhost:8086/");
@@ -44,20 +44,20 @@ class DefaultApiTest extends BasicTest
 
         $request = $this->mockHandler->getLastRequest();
 
-        $this->assertEquals('http://localhost:8086/api/v2/write?org=my-org&bucket=my-bucket&precision=ns', strval($request->getUri()));
+        self::assertEquals('http://localhost:8086/api/v2/write?org=my-org&bucket=my-bucket&precision=ns', strval($request->getUri()));
     }
 
-    public function testContentType()
+    public function testContentType(): void
     {
         $this->mockHandler->append(new Response(204));
         $this->writeApi->write('h2o,location=west value=33i 15');
 
         $request = $this->mockHandler->getLastRequest();
 
-        $this->assertNotEmpty($request->getHeader("Content-Type"));
+        self::assertNotEmpty($request->getHeader("Content-Type"));
     }
 
-    public function testApiException()
+    public function testApiException(): void
     {
         $this->mockHandler->append(new Response(400));
 
@@ -66,7 +66,7 @@ class DefaultApiTest extends BasicTest
         $this->writeApi->write('h2o,location=west value=33i 15');
     }
 
-    public function testInvalidArgument()
+    public function testInvalidArgument(): void
     {
         $this->mockHandler->append(new Response(204));
 
@@ -77,14 +77,14 @@ class DefaultApiTest extends BasicTest
         $this->writeApi->write('h2o,location=west value=33i 15');
     }
 
-    public function testDefaultVerifySSL()
+    public function testDefaultVerifySSL(): void
     {
         $guzzle = $this->property_value($this->property_value($this->writeApi->http, 'client'), 'httpClient');
 
-        $this->assertEquals(true, $guzzle->getConfig()['verify']);
+        self::assertTrue($guzzle->getConfig()['verify']);
     }
 
-    public function testConfigureVerifySSL()
+    public function testConfigureVerifySSL(): void
     {
         $client = new Client([
             "url" => "http://localhost:8086",
@@ -98,12 +98,12 @@ class DefaultApiTest extends BasicTest
 
         $guzzle = $this->property_value($this->property_value($client->createQueryApi()->http, 'client'), 'httpClient');
 
-        $this->assertEquals(false, $guzzle->getConfig()['verify']);
+        self::assertFalse($guzzle->getConfig()['verify']);
 
         $client->close();
     }
 
-    public function testFollowRedirect()
+    public function testFollowRedirect(): void
     {
         $this->mockHandler->append(
             new Response(
@@ -114,13 +114,13 @@ class DefaultApiTest extends BasicTest
         );
         $this->writeApi->write('h2o,location=west value=33i 15');
 
-        $this->assertCount(2, $this->requests);
+        self::assertCount(2, $this->requests);
 
-        $this->assertEquals('Token my-token', $this->getHeader($this->requests[0]['request']));
-        $this->assertEquals('Token my-token', $this->getHeader($this->requests[1]['request']));
+        self::assertEquals('Token my-token', $this->getHeader($this->requests[0]['request']));
+        self::assertEquals('Token my-token', $this->getHeader($this->requests[1]['request']));
     }
 
-    public function testJsonBodyWithMessageReturnsMessage()
+    public function testJsonBodyWithMessageReturnsMessage(): void
     {
         $this->expectException(ApiException::class);
         $this->expectExceptionMessageMatches('~^\[500\].*\(a failure\)$~');
@@ -130,7 +130,7 @@ class DefaultApiTest extends BasicTest
         $this->queryApi->query('some broken query');
     }
 
-    public function testJsonBodyWithErrorReturnsMessage()
+    public function testJsonBodyWithErrorReturnsMessage(): void
     {
         $this->expectException(ApiException::class);
         $this->expectExceptionMessageMatches('~^\[500\].*\(another failure\)$~');

--- a/tests/FluxCsvParserTest.php
+++ b/tests/FluxCsvParserTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 
 class FluxCsvParserTest extends TestCase
 {
-    public function testMultipleValues()
+    public function testMultipleValues(): void
     {
         $data = "#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,long,long,string\n" .
             "#group,false,false,true,true,true,true,true,true,false,false,false\n" .
@@ -26,15 +26,15 @@ class FluxCsvParserTest extends TestCase
         $tables = $fluxCsvParser->parse()->tables;
         $columnHeaders = $tables[0]->columns;
 
-        $this->assertEquals(11, sizeof($columnHeaders));
+        self::assertEquals(11, sizeof($columnHeaders));
         $values = [false, false, true, true, true, true, true, true, false, false, false];
-        $this->assertColumns($columnHeaders, $values);
-        $this->assertEquals(4, sizeof($tables));
+        self::assertColumns($columnHeaders, $values);
+        self::assertEquals(4, sizeof($tables));
 
-        $this->assertMultipleRecords($tables);
+        self::assertMultipleRecords($tables);
     }
 
-    public function testParseShortCut()
+    public function testParseShortCut(): void
     {
         $data = '#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,' .
             "dateTime:RFC3339,long,string,string,string,boolean\n" .
@@ -46,20 +46,20 @@ class FluxCsvParserTest extends TestCase
         $fluxCsvParser = new FluxCsvParser($data);
         $tables = $fluxCsvParser->parse()->tables;
 
-        $this->assertEquals(1, sizeof($tables));
-        $this->assertEquals(1, sizeof($tables[0]->records));
+        self::assertEquals(1, sizeof($tables));
+        self::assertEquals(1, sizeof($tables[0]->records));
 
         $record = $tables[0]->records[0];
-        $this->assertEquals($this->parseTime('1970-01-01T00:00:10Z'), $record->getStart());
-        $this->assertEquals($this->parseTime('1970-01-01T00:00:20Z'), $record->getStop());
-        $this->assertEquals($this->parseTime('1970-01-01T00:00:10Z'), $record->getTime());
+        self::assertEquals($this->parseTime('1970-01-01T00:00:10Z'), $record->getStart());
+        self::assertEquals($this->parseTime('1970-01-01T00:00:20Z'), $record->getStop());
+        self::assertEquals($this->parseTime('1970-01-01T00:00:10Z'), $record->getTime());
 
-        $this->assertEquals(10, sizeof($record->values));
-        $this->assertEquals("free", $record->getField());
-        $this->assertEquals("mem", $record->getMeasurement());
+        self::assertEquals(10, sizeof($record->values));
+        self::assertEquals("free", $record->getField());
+        self::assertEquals("mem", $record->getMeasurement());
     }
 
-    public function testMappingBoolean()
+    public function testMappingBoolean(): void
     {
         $data = '#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,' .
             "dateTime:RFC3339,long,string,string,string,boolean\n" .
@@ -74,21 +74,21 @@ class FluxCsvParserTest extends TestCase
         $fluxCsvParser = new FluxCsvParser($data);
         $tables = $fluxCsvParser->parse()->tables;
 
-        $this->assertEquals(1, sizeof($tables));
-        $this->assertEquals(4, sizeof($tables[0]->records));
+        self::assertEquals(1, sizeof($tables));
+        self::assertEquals(4, sizeof($tables[0]->records));
 
         $records = $tables[0]->records;
 
-        $this->assertEquals(true, $records[0]->values['value']);
-        $this->assertEquals(false, $records[1]->values['value']);
-        $this->assertEquals(false, $records[2]->values['value']);
-        $this->assertEquals(true, $records[3]->values['value']);
+        self::assertEquals(true, $records[0]->values['value']);
+        self::assertEquals(false, $records[1]->values['value']);
+        self::assertEquals(false, $records[2]->values['value']);
+        self::assertEquals(true, $records[3]->values['value']);
     }
 
     /**
      * TODO - PHP supports only signed 64bit integers
      */
-    public function testMappingUnsignedLong()
+    public function testMappingUnsignedLong(): void
     {
         $data = '#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,' .
             "dateTime:RFC3339,long,string,string,string,unsignedLong\n" .
@@ -105,11 +105,11 @@ class FluxCsvParserTest extends TestCase
         $tables = $fluxCsvParser->parse()->tables;
 
         $records = $tables[0]->records;
-        $this->assertEquals($expected, $records[0]->values['value']);
-        $this->assertNull($records[1]->values['value']);
+        self::assertEquals($expected, $records[0]->values['value']);
+        self::assertNull($records[1]->values['value']);
     }
 
-    public function testMappingDouble()
+    public function testMappingDouble(): void
     {
         $data = '#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,' .
             "dateTime:RFC3339,long,string,string,string,double\n" .
@@ -124,11 +124,11 @@ class FluxCsvParserTest extends TestCase
 
         $records = $tables[0]->records;
 
-        $this->assertEquals(12.25, $records[0]->values['value']);
-        $this->assertNull($records[1]->values['value']);
+        self::assertEquals(12.25, $records[0]->values['value']);
+        self::assertNull($records[1]->values['value']);
     }
 
-    public function testMappingBase64Binary()
+    public function testMappingBase64Binary(): void
     {
         $binaryData = 'test value';
         $encodedData = base64_encode($binaryData);
@@ -146,11 +146,11 @@ class FluxCsvParserTest extends TestCase
 
         $records = $tables[0]->records;
 
-        $this->assertEquals($binaryData, $records[0]->values['value']);
-        $this->assertNull($records[1]->values['value']);
+        self::assertEquals($binaryData, $records[0]->values['value']);
+        self::assertNull($records[1]->values['value']);
     }
 
-    public function testMappingDuration()
+    public function testMappingDuration(): void
     {
         $data = '#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339' .
             ",dateTime:RFC3339,long,string,string,string,duration\n" .
@@ -165,11 +165,11 @@ class FluxCsvParserTest extends TestCase
 
         $records = $tables[0]->records;
 
-        $this->assertEquals(125, $records[0]->values['value']);
-        $this->assertNull($records[1]->values['value']);
+        self::assertEquals(125, $records[0]->values['value']);
+        self::assertNull($records[1]->values['value']);
     }
 
-    public function testGroupKey()
+    public function testGroupKey(): void
     {
         $data = '#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,' .
             "dateTime:RFC3339,long,string,string,string,duration\n" .
@@ -182,11 +182,11 @@ class FluxCsvParserTest extends TestCase
         $fluxCsvParser = new FluxCsvParser($data);
         $tables = $fluxCsvParser->parse()->tables;
 
-        $this->assertEquals(10, count($tables[0]->columns));
-        $this->assertEquals(2, count($tables[0]->getGroupKey()));
+        self::assertCount(10, $tables[0]->columns);
+        self::assertCount(2, $tables[0]->getGroupKey());
     }
 
-    public function testUnknownTypeAsString()
+    public function testUnknownTypeAsString(): void
     {
         $data = '#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,' .
             "dateTime:RFC3339,long,string,string,string,unknown\n" .
@@ -201,11 +201,11 @@ class FluxCsvParserTest extends TestCase
 
         $records = $tables[0]->records;
 
-        $this->assertEquals('12.25', $records[0]->values['value']);
-        $this->assertNull($records[1]->values['value']);
+        self::assertEquals('12.25', $records[0]->values['value']);
+        self::assertNull($records[1]->values['value']);
     }
 
-    public function testError()
+    public function testError(): void
     {
         $data = "#datatype,string,string\n" .
             "#group,true,true\n" .
@@ -217,19 +217,19 @@ class FluxCsvParserTest extends TestCase
 
         try {
             $fluxCsvParser->parse();
-            $this->fail();
+            self::fail();
         } catch (FluxQueryError $e) {
-            $this->assertEquals(
+            self::assertEquals(
                 'failed to create physical plan: invalid time bounds from procedure from: bounds contain zero time',
                 $e->getMessage()
             );
-            $this->assertEquals(897, $e->getCode());
+            self::assertEquals(897, $e->getCode());
         } catch (Exception $e) {
-            $this->fail();
+            self::fail();
         }
     }
 
-    public function testErrorWithoutReference()
+    public function testErrorWithoutReference(): void
     {
         $data = "#datatype,string,string\n" .
             "#group,true,true\n" .
@@ -241,19 +241,19 @@ class FluxCsvParserTest extends TestCase
 
         try {
             $fluxCsvParser->parse();
-            $this->fail();
+            self::fail();
         } catch (FluxQueryError $e) {
-            $this->assertEquals(
+            self::assertEquals(
                 'failed to create physical plan: invalid time bounds from procedure from: bounds contain zero time',
                 $e->getMessage()
             );
-            $this->assertEquals(0, $e->getCode());
+            self::assertEquals(0, $e->getCode());
         } catch (Exception $e) {
-            $this->fail();
+            self::fail();
         }
     }
 
-    public function testWithoutTableReference()
+    public function testWithoutTableReference(): void
     {
         $data = ",result,table,_start,_stop,_time,_value,_field,_measurement,host,value\n" .
             ",,0,1970-01-01T00:00:10Z,1970-01-01T00:00:20Z,1970-01-01T00:00:10Z,10,free,mem,A,12.25\n" .
@@ -263,18 +263,18 @@ class FluxCsvParserTest extends TestCase
 
         try {
             $fluxCsvParser->parse();
-            $this->fail();
+            self::fail();
         } catch (FluxCsvParserException $e) {
-            $this->assertEquals(
+            self::assertEquals(
                 'Unable to parse CSV response. FluxTable definition was not found.',
                 $e->getMessage()
             );
         } catch (Exception $e) {
-            $this->fail();
+            self::fail();
         }
     }
 
-    public function testParserErrorUndefinedOffset()
+    public function testParserErrorUndefinedOffset(): void
     {
         $data = "#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string,string,string,string,string\n" .
             "#group,false,false,true,true,false,false,true,true,true,true,true\n" .
@@ -313,14 +313,14 @@ class FluxCsvParserTest extends TestCase
         $parser = new FluxCsvParser($data);
         $tables = $parser->parse()->tables;
 
-        $this->assertEquals(4, sizeof($tables));
-        $this->assertEquals(6, sizeof($tables[0]->records));
-        $this->assertEquals(1, sizeof($tables[1]->records));
-        $this->assertEquals(6, sizeof($tables[2]->records));
-        $this->assertEquals(1, sizeof($tables[3]->records));
+        self::assertEquals(4, sizeof($tables));
+        self::assertEquals(6, sizeof($tables[0]->records));
+        self::assertEquals(1, sizeof($tables[1]->records));
+        self::assertEquals(6, sizeof($tables[2]->records));
+        self::assertEquals(1, sizeof($tables[3]->records));
     }
 
-    public function testResponseWithError()
+    public function testResponseWithError(): void
     {
         $data = "#datatype,string,long,string,string,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string\n" .
             "#group,false,false,true,true,true,true,false,false,true\n" .
@@ -341,19 +341,19 @@ class FluxCsvParserTest extends TestCase
 
         try {
             $fluxCsvParser->parse();
-            $this->fail();
+            self::fail();
         } catch (FluxQueryError $e) {
-            $this->assertEquals(
+            self::assertEquals(
                 'engine: unknown field type for value: xyz',
                 $e->getMessage()
             );
-            $this->assertEquals(0, $e->getCode());
+            self::assertEquals(0, $e->getCode());
         } catch (Exception $e) {
-            $this->fail();
+            self::fail();
         }
     }
 
-    public function testParseExportFromUserInterface()
+    public function testParseExportFromUserInterface(): void
     {
         $data = "#group,false,false,true,true,true,true,true,true,false,false\n" .
             "#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,double,dateTime:RFC3339\n" .
@@ -365,15 +365,15 @@ class FluxCsvParserTest extends TestCase
         $parser = new FluxCsvParser($data);
         $tables = $parser->parse()->tables;
 
-        $this->assertEquals(2, sizeof($tables));
-        $this->assertEquals(1, sizeof($tables[0]->records));
-        $this->assertFalse($tables[0]->columns[0]->group);
-        $this->assertFalse($tables[0]->columns[1]->group);
-        $this->assertTrue($tables[0]->columns[2]->group);
-        $this->assertEquals(1, sizeof($tables[1]->records));
+        self::assertEquals(2, sizeof($tables));
+        self::assertEquals(1, sizeof($tables[0]->records));
+        self::assertFalse($tables[0]->columns[0]->group);
+        self::assertFalse($tables[0]->columns[1]->group);
+        self::assertTrue($tables[0]->columns[2]->group);
+        self::assertEquals(1, sizeof($tables[1]->records));
     }
 
-    public function testParseWithoutDatatype()
+    public function testParseWithoutDatatype(): void
     {
         $data = ",result,table,_start,_stop,_field,_measurement,host,region,_value2,value1,value_str\n" .
             ",,0,1677-09-21T00:12:43.145224192Z,2018-07-16T11:21:02.547596934Z,free,mem,A,west,121,11,test\n" .
@@ -382,16 +382,16 @@ class FluxCsvParserTest extends TestCase
         $parser = new FluxCsvParser($data, false, "only_names");
         $tables = $parser->parse()->tables;
 
-        $this->assertEquals(2, sizeof($tables));
-        $this->assertEquals(11, sizeof($tables[0]->columns));
-        $this->assertEquals(1, sizeof($tables[0]->records));
-        $this->assertEquals(11, sizeof($tables[0]->records[0]->values));
-        $this->assertEquals("0", $tables[0]->records[0]->values['table']);
-        $this->assertEquals("11", $tables[0]->records[0]->values['value1']);
-        $this->assertEquals("west", $tables[0]->records[0]->values['region']);
+        self::assertEquals(2, sizeof($tables));
+        self::assertEquals(11, sizeof($tables[0]->columns));
+        self::assertEquals(1, sizeof($tables[0]->records));
+        self::assertEquals(11, sizeof($tables[0]->records[0]->values));
+        self::assertEquals("0", $tables[0]->records[0]->values['table']);
+        self::assertEquals("11", $tables[0]->records[0]->values['value1']);
+        self::assertEquals("west", $tables[0]->records[0]->values['region']);
     }
 
-    public function testRecordDoesntContainsKey()
+    public function testRecordDoesntContainsKey(): void
     {
         $data = "#group,false,false,true,true,true,true,true,true,false,false\n" .
             "#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,double,dateTime:RFC3339\n" .
@@ -405,14 +405,14 @@ class FluxCsvParserTest extends TestCase
 
         try {
             $record->getValue();
-            $this->fail("Expected exception");
+            self::fail("Expected exception");
         } catch (Exception $e) {
-            $this->assertEquals("Record doesn't contain column named '_value'. " .
+            self::assertEquals("Record doesn't contain column named '_value'. " .
                 "Columns: 'result, table, _start, _stop, _field, _measurement, city, location, value, _time'.", $e->getMessage());
         }
     }
 
-    public function testParseInfinity()
+    public function testParseInfinity(): void
     {
         $data = "#group,false,false,true,true,true,true,true,true,true,true,false,false
 #datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,string,string,double,double
@@ -436,13 +436,13 @@ class FluxCsvParserTest extends TestCase
         $parser = new FluxCsvParser($data);
         $tables = $parser->parse()->tables;
 
-        $this->assertEquals(1, sizeof($tables));
-        $this->assertEquals(12, sizeof($tables[0]->records));
-        $this->assertEquals(INF, $tables[0]->records[10]->values['le']);
-        $this->assertEquals(-INF, $tables[0]->records[11]->values['le']);
+        self::assertEquals(1, sizeof($tables));
+        self::assertEquals(12, sizeof($tables[0]->records));
+        self::assertEquals(INF, $tables[0]->records[10]->values['le']);
+        self::assertEquals(-INF, $tables[0]->records[11]->values['le']);
     }
 
-    public function testParseDuplicateColumnNames()
+    public function testParseDuplicateColumnNames(): void
     {
         $data = "#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,double
 #group,false,false,true,true,false,true,true,false
@@ -456,77 +456,83 @@ class FluxCsvParserTest extends TestCase
         $parser = new FluxCsvParser($data);
         $tables = $parser->parse()->tables;
 
-        $this->assertEquals(1, sizeof($tables));
-        $this->assertEquals(3, sizeof($tables[0]->records));
-        $this->assertEquals(8, sizeof($tables[0]->columns));
-        $this->assertEquals(7, sizeof($tables[0]->records[0]->values));
-        $this->assertEquals(8, sizeof($tables[0]->records[0]->row));
-        $this->assertEquals(25.3, $tables[0]->records[0]->row[7]);
+        self::assertEquals(1, sizeof($tables));
+        self::assertEquals(3, sizeof($tables[0]->records));
+        self::assertEquals(8, sizeof($tables[0]->columns));
+        self::assertEquals(7, sizeof($tables[0]->records[0]->values));
+        self::assertEquals(8, sizeof($tables[0]->records[0]->row));
+        self::assertEquals(25.3, $tables[0]->records[0]->row[7]);
     }
 
-    private function assertColumns(array $columnHeaders, array $values)
+    private function assertColumns(array $columnHeaders, array $values): void
     {
         $i = 0;
         foreach ($values as $value) {
-            $this->assertEquals($value, $columnHeaders[$i]->group, "column assert '" . $columnHeaders[$i]->label . "'");
+            self::assertEquals($value, $columnHeaders[$i]->group, "column assert '" . $columnHeaders[$i]->label . "'");
             $i++;
         }
     }
 
-    private function assertMultipleRecords(array $tables)
+    private function assertMultipleRecords(array $tables): void
     {
         #Record 1
         $tableRecords = $tables[0]->records;
-        $this->assertEquals(1, sizeof($tableRecords));
+        self::assertEquals(1, sizeof($tableRecords));
 
         $values = ['table' => 0, 'host' => 'A', 'region' => 'west', 'value1' => 11, '_value2' => 121,
             'value_str' => 'test'];
 
-        $this->assertRecord($tableRecords[0], $values, 11);
+        self::assertRecord($tableRecords[0], $values, 11);
 
         #Record 2
         $tableRecords = $tables[1]->records;
-        $this->assertEquals(1, sizeof($tableRecords));
+        self::assertEquals(1, sizeof($tableRecords));
 
         $values = ['table' => 1, 'host' => 'B', 'region' => 'west', 'value1' => 22, '_value2' => 484,
             'value_str' => 'test'];
 
-        $this->assertRecord($tableRecords[0], $values, 11);
+        self::assertRecord($tableRecords[0], $values, 11);
 
         #Record 3
         $tableRecords = $tables[2]->records;
-        $this->assertEquals(1, sizeof($tableRecords));
+        self::assertEquals(1, sizeof($tableRecords));
 
         $values = ['table' => 2, 'host' => 'A', 'region' => 'west', 'value1' => 38, '_value2' => 1444,
             'value_str' => 'test'];
 
-        $this->assertRecord($tableRecords[0], $values, 11);
+        self::assertRecord($tableRecords[0], $values, 11);
 
         #Record 4
         $tableRecords = $tables[3]->records;
-        $this->assertEquals(1, sizeof($tableRecords));
+        self::assertEquals(1, sizeof($tableRecords));
 
         $values = ['table' => 3, 'host' => 'A', 'region' => 'west', 'value1' => 49, '_value2' => 2401,
             'value_str' => 'test'];
 
-        $this->assertRecord($tableRecords[0], $values, 11);
+        self::assertRecord($tableRecords[0], $values, 11);
     }
 
-    private function assertRecord(FluxRecord $fluxRecord, array $values, $size = 0, $value = null)
+    /**
+     * @template V of mixed
+     * @param array<string, V> $values
+     * @param int $size
+     * @param V $value
+     */
+    private function assertRecord(FluxRecord $fluxRecord, array $values, int $size = 0, $value = null): void
     {
         foreach ($values as $key => $val) {
-            $this->assertEquals($val, $fluxRecord->values[$key]);
+            self::assertEquals($val, $fluxRecord->values[$key]);
         }
 
-        if ($value == null) {
-            $this->assertNull($value);
+        if ($value === null) {
+            self::assertNull($value);
         } else {
-            $this->assertEquals($value, $fluxRecord->getValue());
+            self::assertEquals($value, $fluxRecord->getValue());
         }
-        $this->assertEquals($size, sizeof($fluxRecord->values));
+        self::assertEquals($size, sizeof($fluxRecord->values));
     }
 
-    private function parseTime(string $timestamp)
+    private function parseTime(string $timestamp): string
     {
         //TODO datetime parsing
         return $timestamp;

--- a/tests/ITBucketServiceTest.php
+++ b/tests/ITBucketServiceTest.php
@@ -16,7 +16,7 @@ require_once('IntegrationBaseTestCase.php');
  */
 class ITBucketServiceTest extends IntegrationBaseTestCase
 {
-    public function testHealthService()
+    public function testHealthService(): void
     {
         $healthService = $this->client->createService(HealthService::class);
         $healthCheck = $healthService->getHealth();
@@ -24,7 +24,7 @@ class ITBucketServiceTest extends IntegrationBaseTestCase
         self::assertEquals("ready for queries and writes", $healthCheck->getMessage());
     }
 
-    public function testFixNanosTimeSerialization()
+    public function testFixNanosTimeSerialization(): void
     {
         self::assertEquals(
             "2020-09-18T08:03:48.12345Z",
@@ -62,7 +62,7 @@ class ITBucketServiceTest extends IntegrationBaseTestCase
         );
     }
 
-    public function testBucketService()
+    public function testBucketService(): void
     {
         /** @var BucketsService $bucketsService */
         $bucketsService = $this->client->createService(BucketsService::class);
@@ -73,7 +73,7 @@ class ITBucketServiceTest extends IntegrationBaseTestCase
         }
     }
 
-    public function testBucketServiceCreateBucket()
+    public function testBucketServiceCreateBucket(): void
     {
         /** @var BucketsService $bucketsService */
         $bucketsService = $this->client->createService(BucketsService::class);
@@ -98,7 +98,7 @@ class ITBucketServiceTest extends IntegrationBaseTestCase
         foreach ($buckets as $bucket) {
             self::assertNotEmpty($bucket->getName());
             self::assertNotEmpty($bucket->getId());
-            if ($bucket->getId() == $respBucket->getId()) {
+            if ($bucket->getId() === $respBucket->getId()) {
                 $findBucket = $bucket;
             }
         }

--- a/tests/ITTaskServiceTest.php
+++ b/tests/ITTaskServiceTest.php
@@ -12,7 +12,7 @@ require_once('IntegrationBaseTestCase.php');
  */
 class ITTaskServiceTest extends IntegrationBaseTestCase
 {
-    public function testCreateTask()
+    public function testCreateTask(): void
     {
         /** @var TasksService $taskService */
         $taskService = $this->client->createService(TasksService::class);

--- a/tests/ITUsersServiceTest.php
+++ b/tests/ITUsersServiceTest.php
@@ -11,7 +11,7 @@ require_once('IntegrationBaseTestCase.php');
  */
 class ITUsersServiceTest extends IntegrationBaseTestCase
 {
-    public function testUserService()
+    public function testUserService(): void
     {
         /** @var UsersService $usersService */
         $usersService = $this->client->createService(UsersService::class);

--- a/tests/IntegrationBaseTestCase.php
+++ b/tests/IntegrationBaseTestCase.php
@@ -10,7 +10,27 @@ use PHPUnit\Framework\TestCase;
 
 class IntegrationBaseTestCase extends TestCase
 {
+    /** @var Client */
     public $client;
+    /**
+     * @var array{
+     *     url: string,
+     *     token: string,
+     *     bucket?: string,
+     *     org?: string,
+     *     precision?: WritePrecision::S|WritePrecision::MS|WritePrecision::US|WritePrecision::NS,
+     *     allow_redirects?: bool,
+     *     debug?: bool,
+     *     logFile?: string,
+     *     httpClient?: \Psr\Http\Client\ClientInterface,
+     *     verifySSL?: bool,
+     *     timeout?: int,
+     *     proxy?: string,
+     *     udpPort?: int<1, 65535>,
+     *     ipVersion?: 4|6,
+     *     tags?: array<string, string>,
+     * } $options
+     */
     public $options;
 
     public function setUp(): void
@@ -33,14 +53,14 @@ class IntegrationBaseTestCase extends TestCase
         $orgService = $this->client->createService(OrganizationsService::class);
         $orgs = $orgService->getOrgs()->getOrgs();
         foreach ($orgs as $org) {
-            if ($org->getName() == $this->options["org"]) {
+            if ($org->getName() === $this->options["org"]) {
                 return $org;
             }
         }
         return null;
     }
 
-    public function generateBucketName()
+    public function generateBucketName(): string
     {
         return "IT-php-bucket-" . microtime();
     }

--- a/tests/InvokableScriptsApiTest.php
+++ b/tests/InvokableScriptsApiTest.php
@@ -10,10 +10,10 @@ require_once('BasicTest.php');
  */
 class InvokableScriptsApiTest extends BasicTest
 {
-    public function testCreateInstance()
+    public function testCreateInstance(): void
     {
         $invokableScriptsApi = $this->client->createInvokableScriptsApi();
 
-        $this->assertNotNull($invokableScriptsApi);
+        self::assertNotNull($invokableScriptsApi);
     }
 }

--- a/tests/PointSettingsTest.php
+++ b/tests/PointSettingsTest.php
@@ -26,17 +26,17 @@ class PointSettingsTest extends TestCase
         ]);
     }
 
-    public function testPointSettings()
+    public function testPointSettings(): void
     {
         $writeApi = $this->client->createWriteApi(null, ['customer' => PointSettingsTest::CUSTOMER_TAG]);
 
         $defaultTags = $writeApi->pointSettings->getDefaultTags();
 
-        $this->assertEquals(PointSettingsTest::ID_TAG, $defaultTags['id']);
-        $this->assertEquals(PointSettingsTest::CUSTOMER_TAG, $defaultTags['customer']);
+        self::assertEquals(PointSettingsTest::ID_TAG, $defaultTags['id']);
+        self::assertEquals(PointSettingsTest::CUSTOMER_TAG, $defaultTags['customer']);
     }
 
-    public function testPointSettingsWithAdd()
+    public function testPointSettingsWithAdd(): void
     {
         putenv("data_center=LA");
 
@@ -46,7 +46,7 @@ class PointSettingsTest extends TestCase
 
         $defaultTags = $writeApi->pointSettings->getDefaultTags();
 
-        $this->assertEquals(PointSettingsTest::ID_TAG, $defaultTags['id']);
-        $this->assertEquals(PointSettingsTest::CUSTOMER_TAG, $defaultTags['customer']);
+        self::assertEquals(PointSettingsTest::ID_TAG, $defaultTags['id']);
+        self::assertEquals(PointSettingsTest::CUSTOMER_TAG, $defaultTags['customer']);
     }
 }

--- a/tests/PointTest.php
+++ b/tests/PointTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 class PointTest extends TestCase
 {
-    public function testToLineProtocol()
+    public function testToLineProtocol(): void
     {
         $pointArgs = new Point(
             'h2o',
@@ -19,7 +19,7 @@ class PointTest extends TestCase
             123
         );
 
-        $this->assertEquals(
+        self::assertEquals(
             'h2o,host=aws,region=us level=5i,saturation="99%" 123',
             $pointArgs->toLineProtocol()
         );
@@ -29,42 +29,42 @@ class PointTest extends TestCase
             'fields' => array('level' => 5, 'saturation' => '99%'),
             'time' => 123));
 
-        $this->assertEquals(
+        self::assertEquals(
             'h2o,host=aws,region=us level=5i,saturation="99%" 123',
             $pointArray->toLineProtocol()
         );
     }
 
-    public function testMeasurementEscape()
+    public function testMeasurementEscape(): void
     {
         $point = new Point('h2 o 2', array('location' => 'europe'), array('level' => 2));
-        $this->assertEquals('h2\\ o\\ 2,location=europe level=2i', $point->toLineProtocol());
+        self::assertEquals('h2\\ o\\ 2,location=europe level=2i', $point->toLineProtocol());
 
         $point = new Point('h2,o', array('location' => 'europe'), array('level' => 2));
-        $this->assertEquals('h2\\,o,location=europe level=2i', $point->toLineProtocol());
+        self::assertEquals('h2\\,o,location=europe level=2i', $point->toLineProtocol());
     }
 
-    public function testEmptyKey()
+    public function testEmptyKey(): void
     {
         $point = Point::measurement('h2o')
             ->addField('level', 2)
             ->addTag('location', 'europe')
             ->addTag('', 'warn');
 
-        $this->assertEquals('h2o,location=europe level=2i', $point->toLineProtocol());
+        self::assertEquals('h2o,location=europe level=2i', $point->toLineProtocol());
     }
 
-    public function testEmptyValue()
+    public function testEmptyValue(): void
     {
         $point = Point::measurement('h2o')
             ->addField('level', 2)
             ->addTag('location', 'europe')
             ->addTag('log', '');
 
-        $this->assertEquals('h2o,location=europe level=2i', $point->toLineProtocol());
+        self::assertEquals('h2o,location=europe level=2i', $point->toLineProtocol());
     }
 
-    public function testTagEscapingKeyAndValue()
+    public function testTagEscapingKeyAndValue(): void
     {
         $point = Point::measurement("h\n2\ro\t_data")
             ->addTag("new\nline", "new\nline")
@@ -72,26 +72,26 @@ class PointTest extends TestCase
             ->addTag("t\tab", "t\tab")
             ->addField("level", 2);
 
-        $this->assertEquals(
+        self::assertEquals(
             "h\\n2\\ro\\t_data,carriage\\rreturn=carriage\\nreturn,new\\nline=new\\nline,t\\tab=t\\tab level=2i",
             $point->toLineProtocol()
         );
     }
 
-    public function testStringableTag()
+    public function testStringableTag(): void
     {
         // this is just a random native class, implementing __toString()
         $tag = new StringableClass();
 
         $point = new Point("data", ['test' => $tag], ['value' => 1]);
 
-        $this->assertStringStartsWith(
+        self::assertStringStartsWith(
             "data,test=stringable",
             $point->toLineProtocol()
         );
     }
 
-    public function testNonStringableTag()
+    public function testNonStringableTag(): void
     {
         $this->expectWarning();
         $this->expectWarningMessage('Tag value for key test cannot be converted to string');
@@ -100,16 +100,16 @@ class PointTest extends TestCase
         $point->toLineProtocol();
     }
 
-    public function testEqualSignEscaping()
+    public function testEqualSignEscaping(): void
     {
         $point = Point::measurement("h=2o")
             ->addTag("l=ocation", "e=urope")
             ->addField("l=evel", 2);
 
-        $this->assertEquals("h=2o,l\\=ocation=e\\=urope l\\=evel=2i", $point->toLineProtocol());
+        self::assertEquals("h=2o,l\\=ocation=e\\=urope l\\=evel=2i", $point->toLineProtocol());
     }
 
-    public function testOverrideTagAndField()
+    public function testOverrideTagAndField(): void
     {
         $point = Point::measurement('h2o')
             ->addTag('location', 'europe')
@@ -118,10 +118,10 @@ class PointTest extends TestCase
             ->addField('level', 2)
             ->addField('level', 3);
 
-        $this->assertEquals('h2o,location=europe2 level=3i', $point->toLineProtocol());
+        self::assertEquals('h2o,location=europe2 level=3i', $point->toLineProtocol());
     }
 
-    public function testFieldTypes()
+    public function testFieldTypes(): void
     {
         $point = Point::measurement('h2o')
             ->addTag('tag_b', 'b')
@@ -134,79 +134,83 @@ class PointTest extends TestCase
             ->addField('string', 'string value');
 
         $expected = 'h2o,tag_a=a,tag_b=b bool=true,n1=-2i,n2=10i,n3=9223372036854775807i,n4=5.5,string="string value"';
-        $this->assertEquals($expected, $point->toLineProtocol());
+        self::assertEquals($expected, $point->toLineProtocol());
     }
 
-    public function testFieldNullValue()
+    public function testFieldNullValue(): void
     {
         $point = Point::measurement('h2o')
             ->addTag('location', 'europe')
             ->addField('level', 2)
             ->addField('warning', null);
 
-        $this->assertEquals('h2o,location=europe level=2i', $point->toLineProtocol());
+        self::assertEquals('h2o,location=europe level=2i', $point->toLineProtocol());
     }
 
-    public function testFieldEscape()
+    public function testFieldEscape(): void
     {
         $point = Point::measurement('h2o')
             ->addTag('location', 'europe')
             ->addField('level', 'string esc"ape value');
 
-        $this->assertEquals('h2o,location=europe level="string esc\"ape value"', $point->toLineProtocol());
+        self::assertEquals('h2o,location=europe level="string esc\"ape value"', $point->toLineProtocol());
 
         $point = Point::measurement('h2o')
             ->addTag('location', 'europe')
             ->addField('level', 'string esc\\ape value');
 
-        $this->assertEquals('h2o,location=europe level="string esc\\\\ape value"', $point->toLineProtocol());
+        self::assertEquals('h2o,location=europe level="string esc\\\\ape value"', $point->toLineProtocol());
     }
 
-    public function testTime()
+    public function testTime(): void
     {
         $point = Point::measurement('h2o')
             ->addTag('location', 'europe')
             ->addField('level', 2)
             ->time(123, WritePrecision::NS);
 
-        $this->assertEquals('h2o,location=europe level=2i 123', $point->toLineProtocol());
+        self::assertEquals('h2o,location=europe level=2i 123', $point->toLineProtocol());
     }
 
     /**
      * @dataProvider providerDateTime
+     * @param DateTime|DateTimeImmutable $time
      */
-    public function testTimeFormatting($time)
+    public function testTimeFormatting($time): void
     {
         $point = Point::measurement('h2o')
             ->addTag('location', 'europe')
             ->addField('level', 2)
             ->time($time, WritePrecision::MS);
 
-        $this->assertEquals('h2o,location=europe level=2i 1444897215000', $point->toLineProtocol());
+        self::assertEquals('h2o,location=europe level=2i 1444897215000', $point->toLineProtocol());
 
         $point = Point::measurement('h2o')
             ->addTag('location', 'europe')
             ->addField('level', 2)
             ->time($time, WritePrecision::S);
 
-        $this->assertEquals('h2o,location=europe level=2i 1444897215', $point->toLineProtocol());
+        self::assertEquals('h2o,location=europe level=2i 1444897215', $point->toLineProtocol());
 
         $point = Point::measurement('h2o')
             ->addTag('location', 'europe')
             ->addField('level', 2)
             ->time($time, WritePrecision::US);
 
-        $this->assertEquals('h2o,location=europe level=2i 1444897215000000', $point->toLineProtocol());
+        self::assertEquals('h2o,location=europe level=2i 1444897215000000', $point->toLineProtocol());
 
         $point = Point::measurement('h2o')
             ->addTag('location', 'europe')
             ->addField('level', 2)
             ->time($time, WritePrecision::NS);
 
-        $this->assertEquals('h2o,location=europe level=2i 1444897215000000000', $point->toLineProtocol());
+        self::assertEquals('h2o,location=europe level=2i 1444897215000000000', $point->toLineProtocol());
     }
 
-    public function providerDateTime()
+    /**
+     * @return array<int, array{DateTime|DateTimeImmutable}>
+     */
+    public function providerDateTime(): array
     {
         return [
             [
@@ -222,7 +226,7 @@ class PointTest extends TestCase
         ];
     }
 
-    public function testTimeFormattingDefault()
+    public function testTimeFormattingDefault(): void
     {
         $time = new DateTime();
         $time->setDate(2015, 10, 15);
@@ -233,75 +237,75 @@ class PointTest extends TestCase
             ->addField('level', 2)
             ->time($time);
 
-        $this->assertEquals('h2o,location=europe level=2i 1444897215000000000', $point->toLineProtocol());
+        self::assertEquals('h2o,location=europe level=2i 1444897215000000000', $point->toLineProtocol());
 
         $point = Point::measurement('h2o')
             ->addTag('location', 'europe')
             ->addField('level', 2)
             ->time($time, null);
 
-        $this->assertEquals('h2o,location=europe level=2i 1444897215000000000', $point->toLineProtocol());
+        self::assertEquals('h2o,location=europe level=2i 1444897215000000000', $point->toLineProtocol());
     }
 
-    public function testTimeString()
+    public function testTimeString(): void
     {
         $point = Point::measurement('h2o')
             ->addTag('location', 'europe')
             ->addField('level', 2)
             ->time('123');
 
-        $this->assertEquals('h2o,location=europe level=2i 123', $point->toLineProtocol());
+        self::assertEquals('h2o,location=europe level=2i 123', $point->toLineProtocol());
     }
 
-    public function testTimeFloat()
+    public function testTimeFloat(): void
     {
         $point = Point::measurement('h2o')
             ->addTag('location', 'europe')
             ->addField('level', 2)
             ->time(102030405060.24);
 
-        $this->assertEquals('h2o,location=europe level=2i 102030405060', $point->toLineProtocol());
+        self::assertEquals('h2o,location=europe level=2i 102030405060', $point->toLineProtocol());
     }
 
-    public function testUtf8()
+    public function testUtf8(): void
     {
         $point = Point::measurement('h2o')
             ->addTag('location', 'Přerov')
             ->addField('level', 2)
             ->time(123);
 
-        $this->assertEquals('h2o,location=Přerov level=2i 123', $point->toLineProtocol());
+        self::assertEquals('h2o,location=Přerov level=2i 123', $point->toLineProtocol());
     }
 
-    public function testWithoutTags()
+    public function testWithoutTags(): void
     {
         $point = Point::measurement('h2o')
             ->addField('level', 2)
             ->time(123);
 
-        $this->assertEquals('h2o level=2i 123', $point->toLineProtocol());
+        self::assertEquals('h2o level=2i 123', $point->toLineProtocol());
     }
 
-    public function testWithoutFields()
+    public function testWithoutFields(): void
     {
         $point = Point::measurement('h2o')
             ->addTag('location', 'europe')
             ->time(123);
 
-        $this->assertNull($point->toLineProtocol());
+        self::assertNull($point->toLineProtocol());
     }
 
-    public function testFromArrayWithoutName()
+    public function testFromArrayWithoutName(): void
     {
         $pointArray = Point::fromArray(array(
             'tags' => array('host' => 'aws', 'region' => 'us'),
             'fields' => array('level' => 5, 'saturation' => '99%'),
             'time' => 123));
 
-        $this->assertNull($pointArray);
+        self::assertNull($pointArray);
     }
 
-    public function testTagNonString()
+    public function testTagNonString(): void
     {
         $point = Point::measurement('h2o')
             ->addTag('location', 'europe')
@@ -309,6 +313,6 @@ class PointTest extends TestCase
             ->addTag('tag_not_null', null)
             ->addField('level', 2);
 
-        $this->assertEquals('h2o,location=europe,tag_not_string=4711 level=2i', $point->toLineProtocol());
+        self::assertEquals('h2o,location=europe,tag_not_string=4711 level=2i', $point->toLineProtocol());
     }
 }

--- a/tests/QueryApiIntegrationTest.php
+++ b/tests/QueryApiIntegrationTest.php
@@ -6,6 +6,8 @@ use DateTime;
 use InfluxDB2\Client;
 use InfluxDB2\Model\WritePrecision;
 use InfluxDB2\Point;
+use InfluxDB2\QueryApi;
+use InfluxDB2\WriteApi;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -13,8 +15,11 @@ use PHPUnit\Framework\TestCase;
  */
 class QueryApiIntegrationTest extends TestCase
 {
+    /** @var Client */
     private $client;
+    /** @var WriteApi */
     private $writeApi;
+    /** @var QueryApi */
     private $queryApi;
 
     /**
@@ -34,13 +39,13 @@ class QueryApiIntegrationTest extends TestCase
         $this->queryApi = $this->client->createQueryApi();
     }
 
-    public function testExistsApi()
+    public function testExistsApi(): void
     {
-        $this->assertNotNull($this->writeApi);
-        $this->assertNotNull($this->queryApi);
+        self::assertNotNull($this->writeApi);
+        self::assertNotNull($this->queryApi);
     }
 
-    public function testQueryRaw()
+    public function testQueryRaw(): void
     {
         $now = new DateTime();
         $measurement = 'h2o_query_' . $now->getTimestamp();
@@ -50,11 +55,11 @@ class QueryApiIntegrationTest extends TestCase
 
         $result = $this->queryApi->queryRaw($query);
 
-        $this->assertStringContainsString(',result,table,_start,_stop,_time,_value,_field,_measurement,location', $result);
-        $this->assertStringContainsString($measurement, $result);
+        self::assertStringContainsString(',result,table,_start,_stop,_time,_value,_field,_measurement,location', $result);
+        self::assertStringContainsString($measurement, $result);
     }
 
-    public function testQuery()
+    public function testQuery(): void
     {
         $now = new DateTime();
         $measurement = 'h2o_query_' . $now->getTimestamp();
@@ -63,20 +68,20 @@ class QueryApiIntegrationTest extends TestCase
 
         $result = $this->queryApi->query($query);
 
-        $this->assertNotNull($result);
-        $this->assertEquals(1, sizeof($result));
+        self::assertNotNull($result);
+        self::assertEquals(1, sizeof($result));
         $records = $result[0]->records;
-        $this->assertEquals(1, sizeof($records));
+        self::assertEquals(1, sizeof($records));
         $record = $records[0];
-        $this->assertEquals($measurement, $record->getMeasurement());
-        $this->assertEquals('europe', $record->values['location']);
-        $this->assertEquals(2, $record->getValue());
-        $this->assertEquals(0, $record->table);
-        $this->assertEquals(0, $record->values['table']);
-        $this->assertEquals('level', $record->getField());
+        self::assertEquals($measurement, $record->getMeasurement());
+        self::assertEquals('europe', $record->values['location']);
+        self::assertEquals(2, $record->getValue());
+        self::assertEquals(0, $record->table);
+        self::assertEquals(0, $record->values['table']);
+        self::assertEquals('level', $record->getField());
     }
 
-    public function testWriteQueryNewLine()
+    public function testWriteQueryNewLine(): void
     {
         $measurement = 'h2o_QueryNewLine_' . (new DateTime())->getTimestamp();
 
@@ -87,13 +92,13 @@ class QueryApiIntegrationTest extends TestCase
         $result = $this->queryApi->query('from(bucket: "my-bucket") |> range(start: 0)
             |> filter(fn: (r) => r._measurement == "' . $measurement . '")');
 
-        $this->assertNotNull($result);
-        $this->assertEquals(1, sizeof($result));
+        self::assertNotNull($result);
+        self::assertEquals(1, sizeof($result));
         $records = $result[0]->records;
-        $this->assertEquals(1, sizeof($records));
+        self::assertEquals(1, sizeof($records));
         $record = $records[0];
 
-        $this->assertEquals("some \r\n value", $record->getValue());
+        self::assertEquals("some \r\n value", $record->getValue());
     }
 
     /**

--- a/tests/QueryApiStreamTest.php
+++ b/tests/QueryApiStreamTest.php
@@ -6,6 +6,8 @@ use DateTime;
 use InfluxDB2\Client;
 use InfluxDB2\Model\WritePrecision;
 use InfluxDB2\Point;
+use InfluxDB2\QueryApi;
+use InfluxDB2\WriteApi;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -13,9 +15,13 @@ use PHPUnit\Framework\TestCase;
  */
 class QueryApiStreamTest extends TestCase
 {
+    /** @var Client */
     private $client;
+    /** @var WriteApi */
     private $writeApi;
+    /** @var QueryApi */
     private $queryApi;
+    /** @var DateTime */
     private $now;
 
     /**
@@ -38,7 +44,7 @@ class QueryApiStreamTest extends TestCase
         $this->now = new DateTime();
     }
 
-    public function testQueryStream()
+    public function testQueryStream(): void
     {
         $measurement = 'h2o_query_stream' . $this->now->format('Y-m-d-H-i-s');
         $this->write(10, $measurement);
@@ -51,20 +57,20 @@ class QueryApiStreamTest extends TestCase
         $parser = $this->queryApi->queryStream($query);
 
         foreach ($parser->each() as $record) {
-            $this->assertNotNull($record);
+            self::assertNotNull($record);
 
-            $this->assertEquals($measurement, $record->getMeasurement());
-            $this->assertEquals('europe', $record->values['location']);
-            $this->assertEquals($count, $record->getValue());
-            $this->assertEquals('level', $record->getField());
+            self::assertEquals($measurement, $record->getMeasurement());
+            self::assertEquals('europe', $record->values['location']);
+            self::assertEquals($count, $record->getValue());
+            self::assertEquals('level', $record->getField());
 
             $count++;
         }
 
-        $this->assertEquals(10, $count);
+        self::assertEquals(10, $count);
     }
 
-    public function testQueryStreamBreak()
+    public function testQueryStreamBreak(): void
     {
         $measurement = 'h2o_query_stream_break' . $this->now->format('Y-m-d-H-i-s');
         $this->write(20, $measurement);
@@ -78,7 +84,7 @@ class QueryApiStreamTest extends TestCase
 
         $records = [];
 
-        $this->assertFalse($parser->closed);
+        self::assertFalse($parser->closed);
 
         foreach ($parser->each() as $record) {
             if ($count >= 5) {
@@ -90,18 +96,18 @@ class QueryApiStreamTest extends TestCase
             $count++;
         }
 
-        $this->assertEquals(5, count($records));
-        $this->assertTrue($parser->closed);
+        self::assertCount(5, $records);
+        self::assertTrue($parser->closed);
     }
 
-    public function testQueryEmptyData()
+    public function testQueryEmptyData(): void
     {
         $result = $this->queryApi->queryStream(null);
 
-        $this->assertNull($result);
+        self::assertNull($result);
     }
 
-    private function write($values, $measurement)
+    private function write(int $values, string $measurement): void
     {
         for ($ii = 0; $ii < $values; $ii++) {
             $this->writeApi->write(

--- a/tests/QueryApiTest.php
+++ b/tests/QueryApiTest.php
@@ -24,7 +24,7 @@ class QueryApiTest extends BasicTest
         . ",,0,1970-01-01T00:00:20Z,1970-01-01T00:00:30Z,1970-01-01T00:00:20Z,11,free,mem,A,west\n"
         . ",,0,1970-01-01T00:00:20Z,1970-01-01T00:00:30Z,1970-01-01T00:00:20Z,22,free,mem,B,west";
 
-    public function testQueryRaw()
+    public function testQueryRaw(): void
     {
         $this->mockHandler->append(new Response(204, [], QueryApiTest::SUCCESS_DATA));
 
@@ -32,10 +32,10 @@ class QueryApiTest extends BasicTest
             'from(bucket:"my-bucket") |> range(start: 1970-01-01T00:00:00.000000001Z) |> last()'
         );
 
-        $this->assertEquals(QueryApiTest::SUCCESS_DATA, $result);
+        self::assertEquals(QueryApiTest::SUCCESS_DATA, $result);
     }
 
-    public function testQuery()
+    public function testQuery(): void
     {
         $this->mockHandler->append(new Response(204, [], QueryApiTest::SUCCESS_DATA));
 
@@ -43,18 +43,18 @@ class QueryApiTest extends BasicTest
         $result = $this->queryApi->query('from(bucket:"' . $bucket
             . '") |> range(start: 1970-01-01T00:00:00.000000001Z) |> last()');
 
-        $this->assertEquals(1, count($result));
-        $this->assertEquals(4, count($result[0]->records));
+        self::assertCount(1, $result);
+        self::assertCount(4, $result[0]->records);
 
         $record = $result[0]->records[0];
 
-        $this->assertEquals('1970-01-01T00:00:10Z', $record->getTime());
-        $this->assertEquals('mem', $record->getMeasurement());
-        $this->assertEquals(10, $record->getValue());
-        $this->assertEquals('free', $record->getField());
+        self::assertEquals('1970-01-01T00:00:10Z', $record->getTime());
+        self::assertEquals('mem', $record->getMeasurement());
+        self::assertEquals(10, $record->getValue());
+        self::assertEquals('free', $record->getField());
     }
 
-    public function testQueryParameterized()
+    public function testQueryParameterized(): void
     {
         $this->mockHandler->append(new Response(204, [], QueryApiTest::SUCCESS_DATA));
         $q = new Query();
@@ -73,31 +73,31 @@ class QueryApiTest extends BasicTest
         $contents = $this->mockHandler->getLastRequest()->getBody()->getContents();
         $json = json_decode($contents, true);
 
-        $this->assertEquals("my-bucket", $json["params"]["bucketParam"]);
-        $this->assertEquals('2021-12-14T11:33:28+00:00', $json["params"]["startParam"]);
+        self::assertEquals("my-bucket", $json["params"]["bucketParam"]);
+        self::assertEquals('2021-12-14T11:33:28+00:00', $json["params"]["startParam"]);
 
-        $this->assertCount(1, $result);
-        $this->assertCount(4, $result[0]->records);
+        self::assertCount(1, $result);
+        self::assertCount(4, $result[0]->records);
 
         $record = $result[0]->records[0];
 
-        $this->assertEquals('1970-01-01T00:00:10Z', $record->getTime());
-        $this->assertEquals('mem', $record->getMeasurement());
-        $this->assertEquals(10, $record->getValue());
-        $this->assertEquals('free', $record->getField());
+        self::assertEquals('1970-01-01T00:00:10Z', $record->getTime());
+        self::assertEquals('mem', $record->getMeasurement());
+        self::assertEquals(10, $record->getValue());
+        self::assertEquals('free', $record->getField());
     }
 
-    public function testQueryRawEmptyData()
+    public function testQueryRawEmptyData(): void
     {
         $result = $this->queryApi->queryRaw('');
 
-        $this->assertNull($result);
+        self::assertNull($result);
     }
 
-    public function testQueryEmptyData()
+    public function testQueryEmptyData(): void
     {
         $result = $this->queryApi->query(null);
 
-        $this->assertNull($result);
+        self::assertNull($result);
     }
 }

--- a/tests/StringableClass.php
+++ b/tests/StringableClass.php
@@ -4,7 +4,7 @@ namespace InfluxDB2Test;
 
 class StringableClass
 {
-    public function __toString()
+    public function __toString(): string
     {
         return "stringable";
     }

--- a/tests/WriteApiBatchingTest.php
+++ b/tests/WriteApiBatchingTest.php
@@ -7,6 +7,7 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use InfluxDB2\ApiException;
 use InfluxDB2\Point;
+use Psr\Http\Message\RequestInterface;
 
 require_once('BasicTest.php');
 /**
@@ -15,12 +16,15 @@ require_once('BasicTest.php');
  */
 class WriteApiBatchingTest extends BasicTest
 {
-    protected function getWriteOptions(): ?array
+    /**
+     * {@inheritDoc}
+     */
+    protected function getWriteOptions(): array
     {
-        return array('writeType' => 2, 'batchSize' => 2);
+        return ['writeType' => 2, 'batchSize' => 2];
     }
 
-    public function testBatchSize()
+    public function testBatchSize(): void
     {
         $this->mockHandler->append(
             new Response(204),
@@ -32,18 +36,18 @@ class WriteApiBatchingTest extends BasicTest
         $this->writeApi->write('h2o_feet,location=coyote_creek level\\ water_level=3.0 3');
         $this->writeApi->write('h2o_feet,location=coyote_creek level\\ water_level=4.0 4');
 
-        $this->assertCount(2, $this->requests);
+        self::assertCount(2, $this->requests);
 
         $result1 = "h2o_feet,location=coyote_creek level\\ water_level=1.0 1\n"
             . "h2o_feet,location=coyote_creek level\\ water_level=2.0 2";
         $result2 = "h2o_feet,location=coyote_creek level\\ water_level=3.0 3\n"
             . "h2o_feet,location=coyote_creek level\\ water_level=4.0 4";
 
-        $this->assertEquals($result1, $this->requests[0]['request']->getBody());
-        $this->assertEquals($result2, $this->requests[1]['request']->getBody());
+        self::assertEquals($result1, $this->requests[0]['request']->getBody());
+        self::assertEquals($result2, $this->requests[1]['request']->getBody());
     }
 
-    public function testBatchSizeGroupBy()
+    public function testBatchSizeGroupBy(): void
     {
         $this->mockHandler->append(
             new Response(204),
@@ -93,51 +97,51 @@ class WriteApiBatchingTest extends BasicTest
             'my-org-a'
         );
 
-        $this->assertCount(5, $this->requests);
+        self::assertCount(5, $this->requests);
 
         $request = $this->requests[0]['request'];
 
-        $this->assertEquals(
+        self::assertEquals(
             'http://localhost:8086/api/v2/write?org=my-org&bucket=my-bucket&precision=ns',
             strval($request->getUri())
         );
-        $this->assertEquals('h2o_feet,location=coyote_creek level\\ water_level=1.0 1', $request->getBody());
+        self::assertEquals('h2o_feet,location=coyote_creek level\\ water_level=1.0 1', $request->getBody());
 
         $request = $this->requests[1]['request'];
 
-        $this->assertEquals(
+        self::assertEquals(
             'http://localhost:8086/api/v2/write?org=my-org&bucket=my-bucket&precision=s',
             strval($request->getUri())
         );
-        $this->assertEquals('h2o_feet,location=coyote_creek level\\ water_level=2.0 2', $request->getBody());
+        self::assertEquals('h2o_feet,location=coyote_creek level\\ water_level=2.0 2', $request->getBody());
 
         $request = $this->requests[2]['request'];
 
-        $this->assertEquals(
+        self::assertEquals(
             'http://localhost:8086/api/v2/write?org=my-org-a&bucket=my-bucket&precision=ns',
             strval($request->getUri())
         );
-        $this->assertEquals("h2o_feet,location=coyote_creek level\\ water_level=3.0 3\n"
+        self::assertEquals("h2o_feet,location=coyote_creek level\\ water_level=3.0 3\n"
             . 'h2o_feet,location=coyote_creek level\\ water_level=4.0 4', $request->getBody());
 
         $request = $this->requests[3]['request'];
 
-        $this->assertEquals(
+        self::assertEquals(
             'http://localhost:8086/api/v2/write?org=my-org-a&bucket=my-bucket2&precision=ns',
             strval($request->getUri())
         );
-        $this->assertEquals('h2o_feet,location=coyote_creek level\\ water_level=5.0 5', $request->getBody());
+        self::assertEquals('h2o_feet,location=coyote_creek level\\ water_level=5.0 5', $request->getBody());
 
         $request = $this->requests[4]['request'];
 
-        $this->assertEquals(
+        self::assertEquals(
             'http://localhost:8086/api/v2/write?org=my-org-a&bucket=my-bucket&precision=ns',
             strval($request->getUri())
         );
-        $this->assertEquals('h2o_feet,location=coyote_creek level\\ water_level=6.0 6', $request->getBody());
+        self::assertEquals('h2o_feet,location=coyote_creek level\\ water_level=6.0 6', $request->getBody());
     }
 
-    public function testFlushAllByCloseClient()
+    public function testFlushAllByCloseClient(): void
     {
         $this->mockHandler->append(new Response(204));
 
@@ -147,22 +151,24 @@ class WriteApiBatchingTest extends BasicTest
         $this->writeApi->write('h2o_feet,location=coyote_creek level\\ water_level=2.0 2');
         $this->writeApi->write('h2o_feet,location=coyote_creek level\\ water_level=3.0 3');
 
-        $this->assertNull($this->mockHandler->getLastRequest());
+        self::assertNull($this->mockHandler->getLastRequest());
 
         $this->client->close();
 
         $request = $this->mockHandler->getLastRequest();
 
-        $this->assertEquals(
+        self::assertInstanceOf(RequestInterface::class, $request);
+
+        self::assertEquals(
             'http://localhost:8086/api/v2/write?org=my-org&bucket=my-bucket&precision=ns',
             strval($request->getUri())
         );
-        $this->assertEquals("h2o_feet,location=coyote_creek level\\ water_level=1.0 1\n"
+        self::assertEquals("h2o_feet,location=coyote_creek level\\ water_level=1.0 1\n"
             . "h2o_feet,location=coyote_creek level\\ water_level=2.0 2\n"
             . 'h2o_feet,location=coyote_creek level\\ water_level=3.0 3', $request->getBody());
     }
 
-    public function testRetryIntervalByConfig()
+    public function testRetryIntervalByConfig(): void
     {
         $errorBody = '{"code":"temporarily unavailable","message":"Token is temporarily over quota.'
             . 'The Retry-After header describes when to try the write again."}';
@@ -176,18 +182,18 @@ class WriteApiBatchingTest extends BasicTest
         $this->writeApi->write('h2o_feet,location=coyote_creek water_level=1.0 1');
         $this->writeApi->write('h2o_feet,location=coyote_creek water_level=2.0 2');
 
-        $this->assertCount(2, $this->requests);
+        self::assertCount(2, $this->requests);
         $request = $this->mockHandler->getLastRequest();
 
-        $this->assertEquals(
+        self::assertEquals(
             'http://localhost:8086/api/v2/write?org=my-org&bucket=my-bucket&precision=ns',
             strval($request->getUri())
         );
-        $this->assertEquals("h2o_feet,location=coyote_creek water_level=1.0 1\n"
+        self::assertEquals("h2o_feet,location=coyote_creek water_level=1.0 1\n"
             . "h2o_feet,location=coyote_creek water_level=2.0 2", $request->getBody()->getContents());
     }
 
-    public function testRetryIntervalByHeader()
+    public function testRetryIntervalByHeader(): void
     {
         $errorBody = '{"code":"temporarily unavailable","message":"Token is temporarily over quota.'
             . 'The Retry-After header describes when to try the write again."}';
@@ -202,18 +208,18 @@ class WriteApiBatchingTest extends BasicTest
         $this->writeApi->write('h2o_feet,location=coyote_creek water_level=1.0 1');
         $this->writeApi->write('h2o_feet,location=coyote_creek water_level=2.0 2');
 
-        $this->assertCount(2, $this->requests);
+        self::assertCount(2, $this->requests);
         $request = $this->mockHandler->getLastRequest();
 
-        $this->assertEquals(
+        self::assertEquals(
             'http://localhost:8086/api/v2/write?org=my-org&bucket=my-bucket&precision=ns',
             strval($request->getUri())
         );
-        $this->assertEquals("h2o_feet,location=coyote_creek water_level=1.0 1\n"
+        self::assertEquals("h2o_feet,location=coyote_creek water_level=1.0 1\n"
             . "h2o_feet,location=coyote_creek water_level=2.0 2", $request->getBody()->getContents());
     }
 
-    public function testRetryIntervalMaxRetries()
+    public function testRetryIntervalMaxRetries(): void
     {
         $errorBody = '{"code":"temporarily unavailable","message":"Token is temporarily over quota.'
             . 'The Retry-After header describes when to try the write again."}';
@@ -231,10 +237,10 @@ class WriteApiBatchingTest extends BasicTest
         $this->writeApi->write('h2o_feet,location=coyote_creek water_level=1.0 1');
         $this->writeApi->write('h2o_feet,location=coyote_creek water_level=2.0 2');
 
-        $this->assertCount(3, $this->requests);
+        self::assertCount(3, $this->requests);
     }
 
-    public function testRetryCount()
+    public function testRetryCount(): void
     {
         $this->mockHandler->append(
         // regular call
@@ -262,16 +268,16 @@ class WriteApiBatchingTest extends BasicTest
         try {
             $this->writeApi->write($point);
         } catch (ApiException $e) {
-            $this->assertEquals(429, $e->getCode());
+            self::assertEquals(429, $e->getCode());
         }
 
-        $this->assertCount(4, $this->requests);
+        self::assertCount(4, $this->requests);
 
         $count = $this->mockHandler->count();
-        $this->assertEquals(1, $count);
+        self::assertEquals(1, $count);
     }
 
-    public function testRetryConnectionError()
+    public function testRetryConnectionError(): void
     {
         $errorMessage = 'Failed to connect to localhost port 8086';
 
@@ -291,10 +297,10 @@ class WriteApiBatchingTest extends BasicTest
         $this->writeApi->write('h2o_feet,location=coyote_creek water_level=1.0 1');
         $this->writeApi->write('h2o_feet,location=coyote_creek water_level=2.0 2');
 
-        $this->assertCount(3, $this->requests);
+        self::assertCount(3, $this->requests);
     }
 
-    public function testJitterInterval()
+    public function testJitterInterval(): void
     {
         $this->mockHandler->append(
             new Response(204),
@@ -310,17 +316,17 @@ class WriteApiBatchingTest extends BasicTest
 
         $time = microtime(true) - $start;
 
-        $this->assertTrue($time > 0 && $time <= 2);
+        self::assertTrue($time > 0 && $time <= 2);
 
-        $this->assertCount(1, $this->requests);
+        self::assertCount(1, $this->requests);
 
         $result1 = "h2o_feet,location=coyote_creek level\\ water_level=1.0 1\n"
             . "h2o_feet,location=coyote_creek level\\ water_level=2.0 2";
 
-        $this->assertEquals($result1, $this->requests[0]['request']->getBody());
+        self::assertEquals($result1, $this->requests[0]['request']->getBody());
     }
 
-    public function testRetryContainsMessage()
+    public function testRetryContainsMessage(): void
     {
         // create log file
         fopen("log_test.txt", "w");
@@ -341,9 +347,9 @@ class WriteApiBatchingTest extends BasicTest
         $this->writeApi->write('h2o_feet,location=coyote_creek water_level=1.0 1');
         $this->writeApi->write('h2o_feet,location=coyote_creek water_level=2.0 2');
 
-        $this->assertCount(2, $this->requests);
+        self::assertCount(2, $this->requests);
 
         $message = file_get_contents("log_test.txt");
-        $this->assertStringContainsString("The retryable error occurred during writing of data. Reason: 'org 04014de4ed590000 has exceeded limited_write plan limit'. Retry in: 3s.", $message);
+        self::assertStringContainsString("The retryable error occurred during writing of data. Reason: 'org 04014de4ed590000 has exceeded limited_write plan limit'. Retry in: 3s.", $message);
     }
 }

--- a/tests/WriteApiIntegrationTest.php
+++ b/tests/WriteApiIntegrationTest.php
@@ -35,19 +35,19 @@ class WriteApiIntegrationTest extends TestCase
         $this->writeApi = $this->client->createWriteApi();
     }
 
-    public function testExistsWriteApi()
+    public function testExistsWriteApi(): void
     {
-        $this->assertNotNull($this->writeApi);
+        self::assertNotNull($this->writeApi);
     }
 
-    public function testWriteApiWriteRaw()
+    public function testWriteApiWriteRaw(): void
     {
         $payload = 'h2o_feet,location=coyote_creek water_level=2.0 2';
         $response = $this->writeApi->writeRaw($payload);
         self::assertNull($response);
     }
 
-    public function testWriteArray()
+    public function testWriteArray(): void
     {
         $data = [
             'name' => "h2o",
@@ -64,7 +64,7 @@ class WriteApiIntegrationTest extends TestCase
         self::assertNull($response);
     }
 
-    public function testBatchingWrite()
+    public function testBatchingWrite(): void
     {
         $writeApi = $this->client->createWriteApi(
             ["writeType"=>WriteType::BATCHING, 'batchSize'=>3]
@@ -91,12 +91,12 @@ class WriteApiIntegrationTest extends TestCase
         $writeApi->write($p5);
         $writeApi->write($p6);
 
-        $this->assertNotNull($writeApi);
+        self::assertNotNull($writeApi);
 
         $this->client->close();
     }
 
-    public function testWriteArrayOfPoint()
+    public function testWriteArrayOfPoint(): void
     {
         $point1 = Point::measurement('h2o')
             ->addTag('location', 'europe')
@@ -113,7 +113,7 @@ class WriteApiIntegrationTest extends TestCase
         self::assertNull($response);
     }
 
-    public function testWriteArrayOfArray()
+    public function testWriteArrayOfArray(): void
     {
         $data1 = [
             'name' => "h2o",

--- a/tests/WriteApiTest.php
+++ b/tests/WriteApiTest.php
@@ -22,28 +22,28 @@ class WriteApiTest extends BasicTest
     private const ID_TAG = "132-987-655";
     private const CUSTOMER_TAG = "California Miner";
 
-    public function setUp($url = "http://localhost:8086", $logFile = "php://output"): void
+    public function setUp(string $url = "http://localhost:8086", string $logFile = "php://output"): void
     {
         parent::setUp($url, $logFile);
 
         putenv("data_center=LA");
     }
 
-    public function testWriteLineProtocol()
+    public function testWriteLineProtocol(): void
     {
         $this->mockHandler->append(new Response(204));
         $this->writeApi->write('h2o,location=west value=33i 15');
 
         $request = $this->mockHandler->getLastRequest();
 
-        $this->assertEquals(
+        self::assertEquals(
             'http://localhost:8086/api/v2/write?org=my-org&bucket=my-bucket&precision=ns',
             strval($request->getUri())
         );
-        $this->assertEquals('h2o,location=west value=33i 15', $request->getBody());
+        self::assertEquals('h2o,location=west value=33i 15', $request->getBody());
     }
 
-    public function testWritePoint()
+    public function testWritePoint(): void
     {
         $this->mockHandler->append(new Response(204));
 
@@ -55,14 +55,14 @@ class WriteApiTest extends BasicTest
 
         $request = $this->mockHandler->getLastRequest();
 
-        $this->assertEquals(
+        self::assertEquals(
             'http://localhost:8086/api/v2/write?org=my-org&bucket=my-bucket&precision=ns',
             strval($request->getUri())
         );
-        $this->assertEquals('h2o,location=europe level=2i', $request->getBody());
+        self::assertEquals('h2o,location=europe level=2i', $request->getBody());
     }
 
-    public function testWriteArray()
+    public function testWriteArray(): void
     {
         $this->mockHandler->append(new Response(204));
 
@@ -75,14 +75,14 @@ class WriteApiTest extends BasicTest
 
         $request = $this->mockHandler->getLastRequest();
 
-        $this->assertEquals(
+        self::assertEquals(
             'http://localhost:8086/api/v2/write?org=my-org&bucket=my-bucket&precision=ns',
             strval($request->getUri())
         );
-        $this->assertEquals('h2o,host=aws,region=us level=5i,saturation="99%" 123', $request->getBody());
+        self::assertEquals('h2o,host=aws,region=us level=5i,saturation="99%" 123', $request->getBody());
     }
 
-    public function testWriteCollection()
+    public function testWriteCollection(): void
     {
         $this->mockHandler->append(new Response(204));
 
@@ -103,38 +103,38 @@ class WriteApiTest extends BasicTest
             . "h2o,location=europe level=2i\n"
             . "h2o,host=aws,region=us level=5i,saturation=\"99%\" 123";
 
-        $this->assertEquals(
+        self::assertEquals(
             'http://localhost:8086/api/v2/write?org=my-org&bucket=my-bucket&precision=ns',
             strval($request->getUri())
         );
-        $this->assertEquals($expected, strval($request->getBody()));
+        self::assertEquals($expected, strval($request->getBody()));
     }
 
-    public function testAuthorizationHeader()
+    public function testAuthorizationHeader(): void
     {
         $this->mockHandler->append(new Response(204));
         $this->writeApi->write('h2o,location=west value=33i 15');
 
         $request = $this->mockHandler->getLastRequest();
 
-        $this->assertEquals(
+        self::assertEquals(
             'http://localhost:8086/api/v2/write?org=my-org&bucket=my-bucket&precision=ns',
             strval($request->getUri())
         );
-        $this->assertEquals('Token my-token', implode(' ', $request->getHeaders()['Authorization']));
+        self::assertEquals('Token my-token', implode(' ', $request->getHeaders()['Authorization']));
     }
 
-    public function testWithoutData()
+    public function testWithoutData(): void
     {
         $this->mockHandler->append(new Response(204));
         $this->writeApi->write('');
 
         $request = $this->mockHandler->getLastRequest();
 
-        $this->assertNull($request);
+        self::assertNull($request);
     }
 
-    public function testInfluxException()
+    public function testInfluxException(): void
     {
         $errorBody = '{"code":"invalid","message":"unable to parse \'h2o_feet, location=coyote_creek water_level=1.0 1\': missing tag key"}';
 
@@ -142,17 +142,17 @@ class WriteApiTest extends BasicTest
 
         try {
             $this->writeApi->write('h2o,location=west value=33i 15');
-            $this->fail();
+            self::fail();
         } catch (ApiException $e) {
-            $this->assertEquals(400, $e->getCode());
-            $this->assertEquals('invalid', implode($e->getResponseHeaders()['X-Platform-Error-Code']));
-            $this->assertEquals($errorBody, strval($e->getResponseBody()));
+            self::assertEquals(400, $e->getCode());
+            self::assertEquals('invalid', implode($e->getResponseHeaders()['X-Platform-Error-Code']));
+            self::assertEquals($errorBody, strval($e->getResponseBody()));
         } catch (Exception $e) {
-            $this->fail();
+            self::fail();
         }
     }
 
-    public function testWritePointWithDefaultTags()
+    public function testWritePointWithDefaultTags(): void
     {
         $this->mockHandler->append(new Response(204));
 
@@ -168,17 +168,17 @@ class WriteApiTest extends BasicTest
 
         $request = $this->mockHandler->getLastRequest();
 
-        $this->assertEquals(
+        self::assertEquals(
             'http://localhost:8086/api/v2/write?org=my-org&bucket=my-bucket&precision=ns',
             strval($request->getUri())
         );
-        $this->assertEquals(
+        self::assertEquals(
             'h2o,customer=California\ Miner,data_center=LA,id=132-987-655,location=europe level=2i',
             strval($request->getBody())
         );
     }
 
-    public function testWriteArrayWithDefaultTags()
+    public function testWriteArrayWithDefaultTags(): void
     {
         $this->mockHandler->append(new Response(204));
 
@@ -195,17 +195,17 @@ class WriteApiTest extends BasicTest
 
         $request = $this->mockHandler->getLastRequest();
 
-        $this->assertEquals(
+        self::assertEquals(
             'http://localhost:8086/api/v2/write?org=my-org&bucket=my-bucket&precision=ns',
             strval($request->getUri())
         );
-        $this->assertEquals(
+        self::assertEquals(
             'h2o,customer=California\ Miner,data_center=LA,host=aws,id=132-987-655,region=us level=5i,saturation="99%" 123',
             strval($request->getBody())
         );
     }
 
-    public function testWriteCollectionWithDefaultTags()
+    public function testWriteCollectionWithDefaultTags(): void
     {
         $this->mockHandler->append(new Response(204));
 
@@ -230,14 +230,14 @@ class WriteApiTest extends BasicTest
             . "h2o,customer=California\ Miner,data_center=LA,id=132-987-655,location=europe level=2i\n"
             . "h2o,customer=California\ Miner,data_center=LA,host=aws,id=132-987-655,region=us level=5i,saturation=\"99%\" 123";
 
-        $this->assertEquals(
+        self::assertEquals(
             'http://localhost:8086/api/v2/write?org=my-org&bucket=my-bucket&precision=ns',
             strval($request->getUri())
         );
-        $this->assertEquals($expected, strval($request->getBody()));
+        self::assertEquals($expected, strval($request->getBody()));
     }
 
-    public function testWriteArrayWithoutTagsWithDefaultTags()
+    public function testWriteArrayWithoutTagsWithDefaultTags(): void
     {
         $this->mockHandler->append(new Response(204));
 
@@ -253,17 +253,17 @@ class WriteApiTest extends BasicTest
 
         $request = $this->mockHandler->getLastRequest();
 
-        $this->assertEquals(
+        self::assertEquals(
             'http://localhost:8086/api/v2/write?org=my-org&bucket=my-bucket&precision=ns',
             strval($request->getUri())
         );
-        $this->assertEquals(
+        self::assertEquals(
             'h2o,customer=California\ Miner,data_center=LA,id=132-987-655 level=5i,saturation="99%" 123',
             strval($request->getBody())
         );
     }
 
-    public function testRetryCount()
+    public function testRetryCount(): void
     {
         $this->mockHandler->append(
         // regular call
@@ -291,11 +291,11 @@ class WriteApiTest extends BasicTest
         $this->expectException(ApiException::class);
         $this->writeApi->write($point);
 
-        $this->assertCount(4, $this->requests);
-        $this->assertCount(1, $this->mockHandler);
+        self::assertCount(4, $this->requests);
+        self::assertCount(1, $this->mockHandler);
     }
 
-    public function testRetryMaxTime()
+    public function testRetryMaxTime(): void
     {
         $this->mockHandler->append(
         // regular call
@@ -321,41 +321,41 @@ class WriteApiTest extends BasicTest
 
         $this->writeApi->write($point);
 
-        $this->assertCount(2, $this->requests);
-        $this->assertCount(1, $this->mockHandler);
+        self::assertCount(2, $this->requests);
+        self::assertCount(1, $this->mockHandler);
     }
 
 
-    public function testRetryBackoffTime()
+    public function testRetryBackoffTime(): void
     {
         $retry = new WriteRetry();
 
         $backoff = $retry->getBackoffTime(1);
-        $this->assertGreaterThanOrEqual(5000, $backoff);
-        $this->assertLessThanOrEqual(10000, $backoff);
+        self::assertGreaterThanOrEqual(5000, $backoff);
+        self::assertLessThanOrEqual(10000, $backoff);
 
         $backoff = $retry->getBackoffTime(2);
-        $this->assertGreaterThanOrEqual(10000, $backoff);
-        $this->assertLessThanOrEqual(20000, $backoff);
+        self::assertGreaterThanOrEqual(10000, $backoff);
+        self::assertLessThanOrEqual(20000, $backoff);
 
         $backoff = $retry->getBackoffTime(3);
-        $this->assertGreaterThanOrEqual(20000, $backoff);
-        $this->assertLessThanOrEqual(40000, $backoff);
+        self::assertGreaterThanOrEqual(20000, $backoff);
+        self::assertLessThanOrEqual(40000, $backoff);
 
         $backoff = $retry->getBackoffTime(4);
-        $this->assertGreaterThanOrEqual(40000, $backoff);
-        $this->assertLessThanOrEqual(80000, $backoff);
+        self::assertGreaterThanOrEqual(40000, $backoff);
+        self::assertLessThanOrEqual(80000, $backoff);
 
         $backoff = $retry->getBackoffTime(5);
-        $this->assertGreaterThanOrEqual(80000, $backoff);
-        $this->assertLessThanOrEqual(125000, $backoff);
+        self::assertGreaterThanOrEqual(80000, $backoff);
+        self::assertLessThanOrEqual(125000, $backoff);
 
         $backoff = $retry->getBackoffTime(6);
-        $this->assertGreaterThanOrEqual(80000, $backoff);
-        $this->assertLessThanOrEqual(125000, $backoff);
+        self::assertGreaterThanOrEqual(80000, $backoff);
+        self::assertLessThanOrEqual(125000, $backoff);
     }
 
-    public function testConnectExceptionRetry()
+    public function testConnectExceptionRetry(): void
     {
         $client = new Client([
             "url" => "http://nonexistenthost:8086/",
@@ -377,7 +377,7 @@ class WriteApiTest extends BasicTest
         try {
             $writeApi->write($point);
         } catch (ApiException $e) {
-            $this->assertEquals(ConnectException::class, get_class($e->getPrevious()));
+            self::assertEquals(ConnectException::class, get_class($e->getPrevious()));
             throw $e;
         }
     }

--- a/tests/WriteUdpTest.php
+++ b/tests/WriteUdpTest.php
@@ -14,6 +14,25 @@ use PHPUnit\Framework\TestCase;
  */
 class WriteUdpTest extends TestCase
 {
+    /**
+     * @var array{
+     *     url: string,
+     *     token: string,
+     *     bucket?: string,
+     *     org?: string,
+     *     precision?: WritePrecision::S|WritePrecision::MS|WritePrecision::US|WritePrecision::NS,
+     *     allow_redirects?: bool,
+     *     debug?: bool,
+     *     logFile?: string,
+     *     httpClient?: \Psr\Http\Client\ClientInterface,
+     *     verifySSL?: bool,
+     *     timeout?: int,
+     *     proxy?: string,
+     *     udpPort?: int<1, 65535>,
+     *     ipVersion?: 4|6,
+     *     tags?: array<string, string>,
+     * } $baseConfig
+     */
     protected $baseConfig = [
         "url" => "http://localhost:8086",
         "token" => "my-token",
@@ -23,6 +42,9 @@ class WriteUdpTest extends TestCase
         "logFile" => "php://output",
     ];
 
+    /**
+     * @return (UdpWriter&\PHPUnit\Framework\MockObject\MockObject)
+     */
     protected function getWriterMock()
     {
         $method = new \ReflectionMethod(UdpWriter::class, 'writeSocket');
@@ -35,21 +57,21 @@ class WriteUdpTest extends TestCase
             ->getMock();
     }
 
-    public function testRequireOptions()
+    public function testRequireOptions(): void
     {
         $client = new Client($this->baseConfig);
         $this->expectException(\Exception::class);
         $client->createUdpWriter();
     }
 
-    public function testValidOptions()
+    public function testValidOptions(): void
     {
         $this->expectNotToPerformAssertions();
         $client = new Client($this->baseConfig + ['udpPort' => 1000]);
         $client->createUdpWriter();
     }
 
-    public function testSocketError()
+    public function testSocketError(): void
     {
         $writer = $this->getWriterMock();
         $writer->method('writeSocket')->willReturn(false);
@@ -57,7 +79,7 @@ class WriteUdpTest extends TestCase
         $writer->write('h2o,location=west value=33i 15');
     }
 
-    public function testLineProtocol()
+    public function testLineProtocol(): void
     {
         $writer = $this->getWriterMock();
         $buffer = '';
@@ -65,10 +87,10 @@ class WriteUdpTest extends TestCase
             $buffer = $data;
         });
         $writer->write('h2o,location=west value=33i 15');
-        $this->assertEquals('h2o,location=west value=33i 15', $buffer);
+        self::assertEquals('h2o,location=west value=33i 15', $buffer);
     }
 
-    public function testWriteArray()
+    public function testWriteArray(): void
     {
         $array = [
             'name' => 'h2o',
@@ -83,10 +105,10 @@ class WriteUdpTest extends TestCase
             $buffer = $data;
         });
         $writer->write($array);
-        $this->assertEquals('h2o,host=aws,region=us level=5i,saturation="99%" 123', $buffer);
+        self::assertEquals('h2o,host=aws,region=us level=5i,saturation="99%" 123', $buffer);
     }
 
-    public function testWriteCollection()
+    public function testWriteCollection(): void
     {
         $point = Point::measurement('h2o')
             ->addTag('location', 'europe')
@@ -108,6 +130,6 @@ class WriteUdpTest extends TestCase
         $expected = "h2o,location=west value=33i 15\n"
             . "h2o,location=europe level=2i\n"
             . "h2o,host=aws,region=us level=5i,saturation=\"99%\" 123";
-        $this->assertEquals($expected, $buffer);
+        self::assertEquals($expected, $buffer);
     }
 }


### PR DESCRIPTION
## Proposed Changes

Adds [PHPStan](https://phpstan.org), fix PHPUnit calls and add missing typehints in tests.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
~- [ ] A test has been added if appropriate~
- [x] `make test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
