### PR TITLE
fix: fix invalid typehints for Point, add missing typehints fo BatchItemKey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Bug Fixes
 1. [#170](https://github.com/influxdata/influxdb-client-php/pull/170): Fix PHP 8.5 deprecations.
+2. [#177](https://github.com/influxdata/influxdb-client-php/pull/177): Fix invalid typehints for Point, add missing typehints for BatchItemKey
 
 ### Others
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -157,24 +157,6 @@ parameters:
 			path: src/InfluxDB2/BatchItem.php
 
 		-
-			message: '#^Method InfluxDB2\\BatchItemKey\:\:__construct\(\) has parameter \$bucket with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/BatchItemKey.php
-
-		-
-			message: '#^Method InfluxDB2\\BatchItemKey\:\:__construct\(\) has parameter \$org with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/BatchItemKey.php
-
-		-
-			message: '#^Method InfluxDB2\\BatchItemKey\:\:__construct\(\) has parameter \$precision with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/BatchItemKey.php
-
-		-
 			message: '#^Call to an undefined method object\:\:getPingWithHttpInfo\(\)\.$#'
 			identifier: method.notFound
 			count: 1
@@ -343,12 +325,6 @@ parameters:
 			path: src/InfluxDB2/DefaultApi.php
 
 		-
-			message: '#^Ternary operator condition is always true\.$#'
-			identifier: ternary.alwaysTrue
-			count: 2
-			path: src/InfluxDB2/DefaultApi.php
-
-		-
 			message: '#^Method InfluxDB2\\FluxColumn\:\:__construct\(\) has parameter \$dataType with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -417,12 +393,6 @@ parameters:
 		-
 			message: '#^Call to function in_array\(\) requires parameter \#3 to be set\.$#'
 			identifier: function.strict
-			count: 1
-			path: src/InfluxDB2/FluxCsvParser.php
-
-		-
-			message: '#^Call to function is_null\(\) with InfluxDB2\\FluxTable will always evaluate to false\.$#'
-			identifier: function.impossibleType
 			count: 1
 			path: src/InfluxDB2/FluxCsvParser.php
 
@@ -655,12 +625,6 @@ parameters:
 			path: src/InfluxDB2/FluxCsvParser.php
 
 		-
-			message: '#^Result of && is always false\.$#'
-			identifier: booleanAnd.alwaysFalse
-			count: 1
-			path: src/InfluxDB2/FluxCsvParser.php
-
-		-
 			message: '#^Class InfluxDB2\\FluxRecord implements generic interface ArrayAccess but does not specify its types\: TKey, TValue$#'
 			identifier: missingType.generics
 			count: 1
@@ -761,300 +725,6 @@ parameters:
 			identifier: missingType.property
 			count: 1
 			path: src/InfluxDB2/InvokableScriptsApi.php
-
-		-
-			message: '#^Call to function is_double\(\) with int will always evaluate to false\.$#'
-			identifier: function.impossibleType
-			count: 1
-			path: src/InfluxDB2/Point.php
-
-		-
-			message: '#^Call to function is_float\(\) with int will always evaluate to false\.$#'
-			identifier: function.impossibleType
-			count: 1
-			path: src/InfluxDB2/Point.php
-
-		-
-			message: '#^Call to function is_long\(\) with mixed will always evaluate to false\.$#'
-			identifier: function.impossibleType
-			count: 1
-			path: src/InfluxDB2/Point.php
-
-		-
-			message: '#^Instanceof between int and DateTimeInterface will always evaluate to false\.$#'
-			identifier: instanceof.alwaysFalse
-			count: 1
-			path: src/InfluxDB2/Point.php
-
-		-
-			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
-			identifier: equal.notAllowed
-			count: 2
-			path: src/InfluxDB2/Point.php
-
-		-
-			message: '#^Method InfluxDB2\\Point\:\:__construct\(\) has parameter \$fields with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/Point.php
-
-		-
-			message: '#^Method InfluxDB2\\Point\:\:__construct\(\) has parameter \$name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/Point.php
-
-		-
-			message: '#^Method InfluxDB2\\Point\:\:__construct\(\) has parameter \$precision with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/Point.php
-
-		-
-			message: '#^Method InfluxDB2\\Point\:\:__construct\(\) has parameter \$tags with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/Point.php
-
-		-
-			message: '#^Method InfluxDB2\\Point\:\:__construct\(\) has parameter \$time with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/Point.php
-
-		-
-			message: '#^Method InfluxDB2\\Point\:\:addField\(\) has parameter \$key with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/Point.php
-
-		-
-			message: '#^Method InfluxDB2\\Point\:\:addField\(\) has parameter \$value with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/Point.php
-
-		-
-			message: '#^Method InfluxDB2\\Point\:\:addTag\(\) has parameter \$key with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/Point.php
-
-		-
-			message: '#^Method InfluxDB2\\Point\:\:appendFields\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/InfluxDB2/Point.php
-
-		-
-			message: '#^Method InfluxDB2\\Point\:\:appendTags\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/InfluxDB2/Point.php
-
-		-
-			message: '#^Method InfluxDB2\\Point\:\:appendTime\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/InfluxDB2/Point.php
-
-		-
-			message: '#^Method InfluxDB2\\Point\:\:escapeKey\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/InfluxDB2/Point.php
-
-		-
-			message: '#^Method InfluxDB2\\Point\:\:escapeKey\(\) has parameter \$escapeEqual with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/Point.php
-
-		-
-			message: '#^Method InfluxDB2\\Point\:\:escapeKey\(\) has parameter \$key with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/Point.php
-
-		-
-			message: '#^Method InfluxDB2\\Point\:\:escapeValue\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/InfluxDB2/Point.php
-
-		-
-			message: '#^Method InfluxDB2\\Point\:\:escapeValue\(\) has parameter \$value with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/Point.php
-
-		-
-			message: '#^Method InfluxDB2\\Point\:\:fromArray\(\) has parameter \$data with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/Point.php
-
-		-
-			message: '#^Method InfluxDB2\\Point\:\:getPrecision\(\) should return string\|null but returns InfluxDB2\\Model\\WritePrecision\.$#'
-			identifier: return.type
-			count: 1
-			path: src/InfluxDB2/Point.php
-
-		-
-			message: '#^Method InfluxDB2\\Point\:\:isNullOrEmptyString\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/InfluxDB2/Point.php
-
-		-
-			message: '#^Method InfluxDB2\\Point\:\:isNullOrEmptyString\(\) has parameter \$str with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/Point.php
-
-		-
-			message: '#^Method InfluxDB2\\Point\:\:measurement\(\) has parameter \$name with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/Point.php
-
-		-
-			message: '#^Method InfluxDB2\\Point\:\:time\(\) has parameter \$precision with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/Point.php
-
-		-
-			message: '#^Method InfluxDB2\\Point\:\:time\(\) has parameter \$time with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/Point.php
-
-		-
-			message: '#^Method InfluxDB2\\Point\:\:toLineProtocol\(\) should return string but returns null\.$#'
-			identifier: return.type
-			count: 1
-			path: src/InfluxDB2/Point.php
-
-		-
-			message: '#^PHPDoc tag @param for parameter \$value with type object\|string\|null is not subtype of native type string\|null\.$#'
-			identifier: parameter.phpDocType
-			count: 1
-			path: src/InfluxDB2/Point.php
-
-		-
-			message: '#^PHPDoc tag @param has invalid value \(\[Array\] data\)\: Unexpected token "\]", expected ''\('' at offset 78 on line 3$#'
-			identifier: phpDoc.parseError
-			count: 1
-			path: src/InfluxDB2/Point.php
-
-		-
-			message: '#^PHPDoc tag @param has invalid value \(\[Array\] fields the fields for the point\)\: Unexpected token "\]", expected ''\('' at offset 206 on line 5$#'
-			identifier: phpDoc.parseError
-			count: 1
-			path: src/InfluxDB2/Point.php
-
-		-
-			message: '#^PHPDoc tag @param has invalid value \(\[Array\] tags the tag set for the point\)\: Unexpected token "\]", expected ''\('' at offset 153 on line 4$#'
-			identifier: phpDoc.parseError
-			count: 1
-			path: src/InfluxDB2/Point.php
-
-		-
-			message: '#^PHPDoc tag @param has invalid value \(\[Integer\] time the timestamp for the point\)\: Unexpected token "\[", expected type at offset 254 on line 6$#'
-			identifier: phpDoc.parseError
-			count: 1
-			path: src/InfluxDB2/Point.php
-
-		-
-			message: '#^PHPDoc tag @param has invalid value \(\[Object\] key the tag name\)\: Unexpected token "\[", expected type at offset 67 on line 3$#'
-			identifier: phpDoc.parseError
-			count: 1
-			path: src/InfluxDB2/Point.php
-
-		-
-			message: '#^PHPDoc tag @param has invalid value \(\[Object\] key the tag name\)\: Unexpected token "\[", expected type at offset 69 on line 3$#'
-			identifier: phpDoc.parseError
-			count: 1
-			path: src/InfluxDB2/Point.php
-
-		-
-			message: '#^PHPDoc tag @param has invalid value \(\[Object\] time the timestamp\)\: Unexpected token "\[", expected type at offset 62 on line 3$#'
-			identifier: phpDoc.parseError
-			count: 1
-			path: src/InfluxDB2/Point.php
-
-		-
-			message: '#^PHPDoc tag @param has invalid value \(\[Object\] value the tag value\)\: Unexpected token "\[", expected type at offset 109 on line 4$#'
-			identifier: phpDoc.parseError
-			count: 1
-			path: src/InfluxDB2/Point.php
-
-		-
-			message: '#^PHPDoc tag @param has invalid value \(\[String\] name the measurement name for the point\.\)\: Unexpected token "\[", expected type at offset 83 on line 3$#'
-			identifier: phpDoc.parseError
-			count: 1
-			path: src/InfluxDB2/Point.php
-
-		-
-			message: '#^PHPDoc tag @param has invalid value \(\[WritePrecision\] precision the precision for the unix timestamps within the body line\-protocol\)\: Unexpected token "\[", expected type at offset 311 on line 7$#'
-			identifier: phpDoc.parseError
-			count: 1
-			path: src/InfluxDB2/Point.php
-
-		-
-			message: '#^PHPDoc tag @param has invalid value \(\[WritePrecision\] precision the timestamp precision\)\: Unexpected token "\[", expected type at offset 104 on line 4$#'
-			identifier: phpDoc.parseError
-			count: 1
-			path: src/InfluxDB2/Point.php
-
-		-
-			message: '#^PHPDoc tag @return with type InfluxDB2\\Model\\WritePrecision is incompatible with native type string\|null\.$#'
-			identifier: return.phpDocType
-			count: 1
-			path: src/InfluxDB2/Point.php
-
-		-
-			message: '#^Property InfluxDB2\\Point\:\:\$fields type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/InfluxDB2/Point.php
-
-		-
-			message: '#^Property InfluxDB2\\Point\:\:\$tags type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/InfluxDB2/Point.php
-
-		-
-			message: '#^Property InfluxDB2\\Point\:\:\$time \(int\) in isset\(\) is not nullable\.$#'
-			identifier: isset.property
-			count: 1
-			path: src/InfluxDB2/Point.php
-
-		-
-			message: '#^Result of \|\| is always false\.$#'
-			identifier: booleanOr.alwaysFalse
-			count: 1
-			path: src/InfluxDB2/Point.php
-
-		-
-			message: '#^Switch condition type \(InfluxDB2\\Model\\WritePrecision\) does not match case condition \\InfluxDB2\\Model\\WritePrecision\:\:MS \(string\)\.$#'
-			identifier: switch.type
-			count: 1
-			path: src/InfluxDB2/Point.php
-
-		-
-			message: '#^Switch condition type \(InfluxDB2\\Model\\WritePrecision\) does not match case condition \\InfluxDB2\\Model\\WritePrecision\:\:S \(string\)\.$#'
-			identifier: switch.type
-			count: 1
-			path: src/InfluxDB2/Point.php
-
-		-
-			message: '#^Switch condition type \(InfluxDB2\\Model\\WritePrecision\) does not match case condition \\InfluxDB2\\Model\\WritePrecision\:\:US \(string\)\.$#'
-			identifier: switch.type
-			count: 1
-			path: src/InfluxDB2/Point.php
 
 		-
 			message: '#^Method InfluxDB2\\PointSettings\:\:__construct\(\) has parameter \$defaultTags with no value type specified in iterable type array\.$#'
@@ -1363,7 +1033,19 @@ parameters:
 			path: src/InfluxDB2/WriteApi.php
 
 		-
+			message: '#^Parameter \#1 \$key of method InfluxDB2\\Point\:\:addTag\(\) expects string, int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/InfluxDB2/WriteApi.php
+
+		-
 			message: '#^Parameter \#1 \$key of method InfluxDB2\\PointSettings\:\:addDefaultTag\(\) expects string, int\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/InfluxDB2/WriteApi.php
+
+		-
+			message: '#^Parameter \#2 \$precision of static method InfluxDB2\\WritePayloadSerializer\:\:generatePayload\(\) expects ''ms''\|''ns''\|''s''\|''us''\|null, string given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/InfluxDB2/WriteApi.php
@@ -1687,19 +1369,25 @@ parameters:
 			path: tests/IntegrationBaseTestCase.php
 
 		-
-			message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertNotNull\(\) with InfluxDB2\\InvokableScriptsApi will always evaluate to true\.$#'
-			identifier: staticMethod.alreadyNarrowedType
-			count: 1
-			path: tests/InvokableScriptsApiTest.php
-
-		-
-			message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertNull\(\) with string will always evaluate to false\.$#'
-			identifier: staticMethod.impossibleType
+			message: '#^Parameter \#1 \$data of static method InfluxDB2\\Point\:\:fromArray\(\) expects array\{name\: string, tags\?\: array\<string, string\|Stringable\>, fields\?\: array\<string, bool\|float\|int\|string\|null\>, time\?\: DateTimeInterface\|float\|int\|null, precision\?\: ''ms''\|''ns''\|''s''\|''us''\|null\}, array\{tags\: array\{host\: ''aws'', region\: ''us''\}, fields\: array\{level\: 5, saturation\: ''99%%''\}, time\: 123\} given\.$#'
+			identifier: argument.type
 			count: 1
 			path: tests/PointTest.php
 
 		-
-			message: '#^Parameter \#2 \$value of method InfluxDB2\\Point\:\:addTag\(\) expects string\|null, int given\.$#'
+			message: '#^Parameter \#1 \$time of method InfluxDB2\\Point\:\:time\(\) expects DateTimeInterface\|float\|int, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/PointTest.php
+
+		-
+			message: '#^Parameter \#2 \$tags of class InfluxDB2\\Point constructor expects array\<string, string\|Stringable\>\|null, array\<string, array\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/PointTest.php
+
+		-
+			message: '#^Parameter \#2 \$value of method InfluxDB2\\Point\:\:addTag\(\) expects string\|Stringable\|null, int given\.$#'
 			identifier: argument.type
 			count: 1
 			path: tests/PointTest.php
@@ -1727,12 +1415,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: tests/WriteApiBatchingTest.php
-
-		-
-			message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertNotNull\(\) with InfluxDB2\\WriteApi will always evaluate to true\.$#'
-			identifier: staticMethod.alreadyNarrowedType
-			count: 1
-			path: tests/WriteApiIntegrationTest.php
 
 		-
 			message: '#^Parameter \#1 \$glue of function implode expects array, string given\.$#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -21,6 +21,7 @@ parameters:
         - src
         - tests
     phpVersion: 70400
+    treatPhpDocTypesAsCertain: false
     ignoreErrors:
         -
             message: '''

--- a/src/InfluxDB2/BatchItemKey.php
+++ b/src/InfluxDB2/BatchItemKey.php
@@ -13,13 +13,32 @@ class BatchItemKey
     public $bucket;
     /** @var string */
     public $org;
-    /** @var WritePrecision */
+    /** @var WritePrecision::S|WritePrecision::MS|WritePrecision::US|WritePrecision::NS|null */
     public $precision;
 
-    public function __construct($bucket, $org, $precision)
+    /**
+     * @param string $bucket
+     * @param string $org
+     * @param WritePrecision::S|WritePrecision::MS|WritePrecision::US|WritePrecision::NS|null $precision
+     * @throws \InvalidArgumentException if $precision is not valid
+     */
+    public function __construct(string $bucket, string $org, ?string $precision)
     {
         $this->bucket    = $bucket;
         $this->org       = $org;
         $this->precision = $precision;
+
+        if (
+            $precision !== null &&
+            !in_array($precision, WritePrecision::getAllowableEnumValues(), true)
+        ) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Invalid value for $precision: %s. Allowed values are: %s',
+                    $precision,
+                    implode(', ', WritePrecision::getAllowableEnumValues())
+                )
+            );
+        }
     }
 }

--- a/src/InfluxDB2/Point.php
+++ b/src/InfluxDB2/Point.php
@@ -11,29 +11,29 @@ class Point
 
     /** @var string */
     private $name;
-    /** @var array */
+    /** @var array<string, string|\Stringable|null>|null */
     private $tags;
-    /** @var array */
+    /** @var array<string, float|int|string|bool|null>|null */
     private $fields;
-    /** @var int */
+    /** @var int|float|DateTimeInterface|null */
     private $time;
-    /** @var WritePrecision */
+    /** @var WritePrecision::S|WritePrecision::MS|WritePrecision::US|WritePrecision::NS|null */
     private $precision;
 
     /** Create DataPoint instance for specified measurement name.
      *
-     * @param [String] name the measurement name for the point.
-     * @param [Array] tags the tag set for the point
-     * @param [Array] fields the fields for the point
-     * @param [Integer] time the timestamp for the point
-     * @param [WritePrecision] precision the precision for the unix timestamps within the body line-protocol
+     * @param string $name the measurement name for the point.
+     * @param array<string, string|\Stringable>|null $tags the tag set for the point
+     * @param array<string, float|int|string|bool|null>|null $fields the fields for the point
+     * @param int|float|DateTimeInterface|null $time the timestamp for the point
+     * @param WritePrecision::S|WritePrecision::MS|WritePrecision::US|WritePrecision::NS|null $precision the precision for the unix timestamps within the body line-protocol
      */
     public function __construct(
-        $name,
-        $tags = null,
-        $fields =  null,
+        string $name,
+        ?array $tags = null,
+        ?array $fields = null,
         $time = null,
-        $precision = Point::DEFAULT_WRITE_PRECISION
+        ?string $precision = Point::DEFAULT_WRITE_PRECISION
     ) {
         $this->name = $name;
         $this->tags = $tags;
@@ -43,24 +43,30 @@ class Point
     }
 
     /**
-     * @return WritePrecision
+     * @return WritePrecision::S|WritePrecision::MS|WritePrecision::US|WritePrecision::NS|null
      */
     public function getPrecision(): ?string
     {
         return $this->precision;
     }
 
-    public static function measurement($name): Point
+    public static function measurement(string $name): Point
     {
         return new Point($name);
     }
 
     /** Create DataPoint instance from specified data.
      *
-     * @param [Array] data
+     * @param array{
+     *     name: string,
+     *     tags?: array<string, string|\Stringable>,
+     *     fields?: array<string, float|int|string|bool|null>,
+     *     time?: int|float|DateTimeInterface|null,
+     *     precision?: WritePrecision::S|WritePrecision::MS|WritePrecision::US|WritePrecision::NS|null,
+     * } $data
      * @return Point
      */
-    public static function fromArray($data): ?Point
+    public static function fromArray(array $data): ?Point
     {
         if (!array_key_exists('name', $data)) {
             return null;
@@ -76,11 +82,11 @@ class Point
 
     /** Adds or replaces a tag value for a point.
      *
-     * @param [Object] key the tag name
-     * @param string|object|null $value the tag value, can be "object" with "__toString" function or "object" implements Stringable interface
+     * @param string $key the tag name
+     * @param string|\Stringable|null $value the tag value, can be "object" with "__toString" function or "object" implements Stringable interface
      * @return Point
      */
-    public function addTag($key, ?string $value): Point
+    public function addTag(string $key, $value): Point
     {
         $this->tags[$key] = $value;
 
@@ -89,11 +95,11 @@ class Point
 
     /** Adds or replaces a field value for a point.
      *
-     * @param [Object] key the tag name
-     * @param [Object] value the tag value
+     * @param string $key the field name
+     * @param float|int|string|bool|null $value the field value
      * @return Point
      */
-    public function addField($key, $value): Point
+    public function addField(string $key, $value): Point
     {
         $this->fields[$key] = $value;
 
@@ -102,8 +108,8 @@ class Point
 
     /** Updates the timestamp for the point.
      *
-     * @param [Object] time the timestamp
-     * @param [WritePrecision] precision the timestamp precision
+     * @param int|float|DateTimeInterface $time the timestamp
+     * @param WritePrecision::S|WritePrecision::MS|WritePrecision::US|WritePrecision::NS|null $precision the timestamp precision
      * @return Point
      */
     public function time($time, $precision = null): Point
@@ -118,7 +124,7 @@ class Point
      *
      * @return string representation of the point
      */
-    public function toLineProtocol()
+    public function toLineProtocol(): ?string
     {
         $measurement = $this->escapeKey($this->name, false);
 
@@ -149,11 +155,11 @@ class Point
         return $lineProtocol;
     }
 
-    private function appendTags()
+    private function appendTags(): ?string
     {
         $tags = '';
 
-        if ($this->tags == null) {
+        if ($this->tags === null) {
             return null;
         }
 
@@ -185,11 +191,11 @@ class Point
         return $tags;
     }
 
-    private function appendFields()
+    private function appendFields(): ?string
     {
         $fields = '';
 
-        if ($this->fields == null) {
+        if ($this->fields === null) {
             return null;
         }
 
@@ -204,7 +210,7 @@ class Point
 
             $fields .= $this->escapeKey($key) . '=';
 
-            if (is_integer($value) || is_long($value)) {
+            if (is_integer($value)) {
                 $fields .= $value . 'i';
             } elseif (is_string($value)) {
                 $fields .= '"' . $this->escapeValue($value) . '"';
@@ -220,7 +226,7 @@ class Point
         return rtrim($fields, ',');
     }
 
-    private function appendTime()
+    private function appendTime(): ?string
     {
         if (!isset($this->time)) {
             return null;
@@ -228,7 +234,7 @@ class Point
 
         $time = $this->time;
 
-        if (is_double($time) || is_float($time)) {
+        if (is_float($time)) {
             $time = round($time);
         } elseif ($time instanceof DateTimeInterface) {
             $seconds = $time->getTimestamp();
@@ -252,7 +258,7 @@ class Point
         return ' ' . $time;
     }
 
-    private function escapeKey($key, $escapeEqual = true)
+    private function escapeKey(string $key, bool $escapeEqual = true): string
     {
         $escapeKeys = array(' ' => '\\ ', ',' => '\\,', "\\" => '\\\\',
             "\n" => '\\n', "\r" => '\\r', "\t" => '\\t');
@@ -264,14 +270,17 @@ class Point
         return strtr($key, $escapeKeys);
     }
 
-    private function escapeValue($value)
+    private function escapeValue(string $value): string
     {
         $escapeValues = array('"' => '\\"', "\\" => '\\\\');
         return strtr($value, $escapeValues);
     }
 
-    private function isNullOrEmptyString($str)
+    /**
+     * @param string|\Stringable|null $str
+     */
+    private function isNullOrEmptyString($str): bool
     {
-        return (!is_string($str) || trim($str) === '');
+        return !is_string($str) || trim($str) === '';
     }
 }

--- a/src/InfluxDB2/WriteApi.php
+++ b/src/InfluxDB2/WriteApi.php
@@ -2,6 +2,8 @@
 
 namespace InfluxDB2;
 
+use InfluxDB2\Model\WritePrecision;
+
 /**
  * Write time series data into InfluxDB.
  * @package InfluxDB2
@@ -57,7 +59,7 @@ class WriteApi extends DefaultApi implements Writer
      *
      * @param string|Point|array $data DataPoints to write into InfluxDB. The data could be represent by
      * array, Point, string
-     * @param string|null $precision The precision for the unix timestamps within the body line-protocol @see \InfluxDB2\Model\WritePrecision
+     * @param WritePrecision::S|WritePrecision::MS|WritePrecision::US|WritePrecision::NS|null $precision The precision for the unix timestamps within the body line-protocol @see \InfluxDB2\Model\WritePrecision
      * @param string|null $bucket specifies the destination bucket for writes
      * @param string|null $org specifies the destination organization for writes
      * @throws ApiException
@@ -167,6 +169,6 @@ class WriteApi extends DefaultApi implements Writer
 
     private function getOption(string $optionName, ?string $precision = null): string
     {
-        return isset($precision) ? $precision : $this->options["$optionName"];
+        return $precision ?? $this->options["$optionName"];
     }
 }

--- a/src/InfluxDB2/WritePayloadSerializer.php
+++ b/src/InfluxDB2/WritePayloadSerializer.php
@@ -3,13 +3,15 @@
 
 namespace InfluxDB2;
 
+use InfluxDB2\Model\WritePrecision;
+
 class WritePayloadSerializer
 {
     /**
      * Generate payload from provided data.
      *
      * @param $data string|Point|array to generate payload
-     * @param string|null $precision the precision used as a key for Batch
+     * @param WritePrecision::S|WritePrecision::MS|WritePrecision::US|WritePrecision::NS|null $precision the precision used as a key for Batch
      * @param string|null $bucket the bucket used as a key for Batch
      * @param string|null $org the org used as a key for Batch
      * @param int|null $writeType specify type of writes - WriteType::SYNCHRONOUS or WriteType::BATCHING

--- a/tests/FluxCsvParserTest.php
+++ b/tests/FluxCsvParserTest.php
@@ -7,6 +7,7 @@ use InfluxDB2\FluxCsvParser;
 use InfluxDB2\FluxCsvParserException;
 use InfluxDB2\FluxQueryError;
 use InfluxDB2\FluxRecord;
+use InfluxDB2\FluxTable;
 use PHPUnit\Framework\TestCase;
 
 class FluxCsvParserTest extends TestCase
@@ -524,10 +525,10 @@ class FluxCsvParserTest extends TestCase
             self::assertEquals($val, $fluxRecord->values[$key]);
         }
 
-        if ($value === null) {
-            self::assertNull($value);
-        } else {
+        if ($value instanceof FluxTable) {
             self::assertEquals($value, $fluxRecord->getValue());
+        } else {
+            self::assertNull($value);
         }
         self::assertEquals($size, sizeof($fluxRecord->values));
     }


### PR DESCRIPTION
## Proposed Changes

Fixes typehints in `Point` class and adds typehints for `BatchItemKey` class.
Should supersede stale PR #148 which now requires rebase to merge.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
~- [ ] A test has been added if appropriate~
- [x] `make test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
