### PR TITLE
feat: add PHP 7.4 typehints, set PHP 7.4 as minimal supported PHP ver…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,7 @@ jobs:
       shell: bash
     steps:
       - checkout
-      - run: choco install php --version=7.3.15 --params '"/ThreadSafe /InstallDir:c:\tools\php"'
+      - run: choco install php --version=7.4.33 --params '"/ThreadSafe /InstallDir:c:\tools\php"'
       - run: cp ~/project/.circleci/php.ini /c/tools/php/
       - run: /c/tools/php/php.exe -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
       - run: /c/tools/php/php.exe composer-setup.php
@@ -157,8 +157,8 @@ jobs:
       - checkout
       - run: |
           mkdir -p tools/php-cs-fixer
-          composer require --working-dir=tools/php-cs-fixer friendsofphp/php-cs-fixer:2.18.7
-          tools/php-cs-fixer/vendor/bin/php-cs-fixer fix --dry-run --verbose --show-progress=estimating --using-cache=no --diff
+          composer require --working-dir=tools/php-cs-fixer friendsofphp/php-cs-fixer:3.95.18
+          tools/php-cs-fixer/vendor/bin/php-cs-fixer fix --dry-run --verbose --show-progress=bar --using-cache=no --diff
   phpstan:
     docker:
       - image: *default-php-image
@@ -202,15 +202,20 @@ workflows:
           php-image: "cimg/php:8.2"
           xdebug-package: "xdebug"
       - tests-php:
+          name: php-8.3
+          php-image: "cimg/php:8.3"
+          xdebug-package: "xdebug"
+      - tests-php:
+          name: php-8.4
+          php-image: "cimg/php:8.4"
+          xdebug-package: "xdebug"
+      - tests-php:
           name: php-8.5
           php-image: "cimg/php:8.5"
           xdebug-package: "xdebug"
       - tests-php:
           name: php-7.4-nightly
           influxdb-image: "quay.io/influxdb/influxdb:nightly"
-      - tests-php:
-          name: php-7.3
-          php-image: "cimg/php:7.3"
       - tests-windows:
           name: php-windows
       - tests-cURL:

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,5 +1,6 @@
 <?php
-return PhpCsFixer\Config::create()
+
+return (new PhpCsFixer\Config())
     ->setFinder(
         PhpCsFixer\Finder::create()
             ->exclude('src/InfluxDB2/Model')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 3.9.0 [unreleased]
 
+### Features
+1. [#178](https://github.com/influxdata/influxdb-client-php/pull/178): Add PHP 7.4 typehints. PHP minimum version is PHP 7.4.
+
 ### Bug Fixes
 1. [#170](https://github.com/influxdata/influxdb-client-php/pull/170): Fix PHP 8.5 deprecations.
 2. [#177](https://github.com/influxdata/influxdb-client-php/pull/177): Fix invalid typehints for Point, add missing typehints for BatchItemKey

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2-cli AS dev
+FROM php:7.4-cli AS dev
 
 COPY --from=composer /usr/bin/composer /usr/bin/
 

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "homepage": "https://www.github.com/influxdata/influxdb-client-php",
   "license": "MIT",
   "require": {
-    "php": ">=7.2",
+    "php": ">=7.4",
     "ext-curl": "*",
     "ext-json": "*",
     "ext-mbstring": "*",
@@ -16,14 +16,14 @@
     "psr/http-client": "^1.0.1"
   },
   "require-dev": {
-    "phpunit/phpunit": "^8.5.27",
+    "phpunit/phpunit": "^9.6.35",
     "squizlabs/php_codesniffer": "~4.0",
-    "guzzlehttp/guzzle": "^7.0.1",
-    "guzzlehttp/psr7": "^2.0.0",
-    "phpstan/phpstan": "^1.12.33 || ^2.2.6",
-    "phpstan/phpstan-deprecation-rules": "^1.2.1 || ^2.0.4",
-    "phpstan/phpstan-phpunit": "^1.4.2 || ^2.0.18",
-    "phpstan/phpstan-strict-rules": "^1.6.2 || ^2.0.12"
+    "guzzlehttp/guzzle": "^7.0.1 || ^8.0.0",
+    "guzzlehttp/psr7": "^2.0.0 || ^3.0.0",
+    "phpstan/phpstan": "^2.2.6",
+    "phpstan/phpstan-deprecation-rules": "^2.0.4",
+    "phpstan/phpstan-phpunit": "^2.0.18",
+    "phpstan/phpstan-strict-rules": "^2.0.12"
   },
   "suggest": {
     "ext-sockets": "Required for UDP writer."
@@ -39,6 +39,8 @@
     }
   },
   "scripts": {
+    "phpstan": "vendor/bin/phpstan analyse",
+    "phpstan-baseline": "vendor/bin/phpstan analyse --generate-baseline",
     "test": "vendor/bin/phpunit tests",
     "test-coverage": "vendor/bin/phpunit tests --log-junit build/junit.xml -v --coverage-html=build/coverage-report"
   },

--- a/examples/BucketManagementExample.php
+++ b/examples/BucketManagementExample.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Shows how to create, list and delete Buckets
  */
@@ -6,8 +7,11 @@
 require __DIR__ . '/../vendor/autoload.php';
 
 use InfluxDB2\Client;
+use InfluxDB2\Model\Bucket;
 use InfluxDB2\Model\BucketRetentionRules;
+use InfluxDB2\Model\Buckets;
 use InfluxDB2\Model\Organization;
+use InfluxDB2\Model\Organizations;
 use InfluxDB2\Model\PostBucketRequest;
 use InfluxDB2\Service\BucketsService;
 use InfluxDB2\Service\OrganizationsService;
@@ -30,13 +34,15 @@ $client = new Client([
 //
 // Function for getting organization ID
 //
-function findMyOrg($client): ?Organization
+function findMyOrg(Client $client): ?Organization
 {
-    /** @var OrganizationsService $orgService */
     $orgService = $client->createService(OrganizationsService::class);
-    $orgs = $orgService->getOrgs()->getOrgs();
-    foreach ($orgs as $org) {
-        if ($org->getName() == $client->options["org"]) {
+    assert($orgService instanceof OrganizationsService);
+    $orgs = $orgService->getOrgs();
+    assert($orgs instanceof Organizations);
+    foreach ($orgs->getOrgs() as $org) {
+        assert($org instanceof Organization);
+        if ($org->getName() === $client->options["org"]) {
             return $org;
         }
     }
@@ -62,9 +68,9 @@ $bucketRequest->setName($bucketName)
     ->setOrgId(findMyOrg($client)->getId());
 
 $respBucket = $bucketsService->postBuckets($bucketRequest);
-
+assert($respBucket instanceof Bucket);
 $bucketName = $respBucket->getName();
-$bucketId = $respBucket->getID();
+$bucketId = $respBucket->getId();
 $createdAt = $respBucket->getCreatedAt()->format('Y-m-d H:i:s');
 
 print  "ID: $bucketId       Created: $createdAt     Name: $bucketName was created\n";
@@ -74,10 +80,12 @@ print  "ID: $bucketId       Created: $createdAt     Name: $bucketName was create
 //
 print "\n\n----------------------------------------- Bucket List -----------------------------------------\n";
 $bucketList = $bucketsService->getBuckets();
+assert($bucketList instanceof Buckets);
 
 foreach ($bucketList->getBuckets() as $item) {
+    assert($item instanceof Bucket);
     $bucketName = $item->getName();
-    $bucketId = $item->getID();
+    $bucketId = $item->getId();
     $createdAt = $item->getCreatedAt()->format('Y-m-d H:i:s');
 
     print  "ID: $bucketId       Created: $createdAt     Name: $bucketName \n";
@@ -88,7 +96,9 @@ foreach ($bucketList->getBuckets() as $item) {
 //
 print "\n\n----------------------------------------- Bucket delete -----------------------------------------\n";
 $bucketList = $bucketsService->getBuckets();
+assert($bucketList instanceof Buckets);
 foreach ($bucketList->getBuckets() as $item) {
+    assert($item instanceof Bucket);
     $bucketName = $item->getName();
     if (strpos($bucketName, 'example-bucket') !== false) {
         $createdAt = $item->getCreatedAt()->format('Y-m-d H:i:s');

--- a/examples/DeleteDataExample.php
+++ b/examples/DeleteDataExample.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Shows how to delete data from InfluxDB by client
  */

--- a/examples/InfluxDB_18_Example.php
+++ b/examples/InfluxDB_18_Example.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Shows how to use forward compatibility APIs from InfluxDB 1.8.
  */

--- a/examples/InvokableScripts.php
+++ b/examples/InvokableScripts.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Show to use Invokable scripts Cloud API to create custom endpoints that query data
  *

--- a/examples/ParameterizedQuery.php
+++ b/examples/ParameterizedQuery.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Shows how to use parameterized queries
  */

--- a/examples/QueryFromFileExample.php
+++ b/examples/QueryFromFileExample.php
@@ -53,7 +53,17 @@ $queryApi = $client->createQueryApi();
 //
 $filename = "query.flux";
 $handle = fopen($filename, "r");
-$contents = fread($handle, filesize($filename));
+if (!is_resource($handle)) {
+    throw new Exception("Unable to open file $filename");
+}
+$fileSize = filesize($filename);
+if ($fileSize === false) {
+    throw new Exception("Unable to get file size of $filename");
+}
+$contents = fread($handle, $fileSize);
+if ($contents === false) {
+    throw new Exception("Unable to read file $filename");
+}
 fclose($handle);
 
 $result = $queryApi->query($contents);
@@ -74,7 +84,7 @@ foreach ($result as $table) {
 
 function getDayName(int $weekDay): string
 {
-    switch ($weekDay) {
+    switch ((string) $weekDay) {
         case "1":
             return "Monday";
         case "2":

--- a/examples/WriteBatchingExample.php
+++ b/examples/WriteBatchingExample.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Shows how to use batching for more performance writes.
  */

--- a/examples/WriteExample.php
+++ b/examples/WriteExample.php
@@ -23,7 +23,7 @@ $client = new Client([
 //
 // Function for checking results
 //
-function checkResult(string  $filterName, Client  $client, string $comment)
+function checkResult(string  $filterName, Client  $client, string $comment): void
 {
     $query = "from(bucket: \"my-bucket\")
     |> range(start: 0)

--- a/examples/WriteUDPExample.php
+++ b/examples/WriteUDPExample.php
@@ -56,7 +56,7 @@ try {
             print "$measurement:   Temperature in $location at $dateTime is $temperature °C\n";
         }
     }
-} catch (Exception|Throwable $e) {
+} catch (Throwable $e) {
     print "\n\n $e \n\n";
 }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,38 +1,14 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Call to an undefined method object\:\:deleteBucketsID\(\)\.$#'
-			identifier: method.notFound
+			message: '#^Call to method InfluxDB2\\Model\\Bucket\:\:getId\(\) with incorrect case\: getID$#'
+			identifier: method.nameCase
 			count: 1
 			path: examples/BucketManagementExample.php
 
 		-
-			message: '#^Call to an undefined method object\:\:getBuckets\(\)\.$#'
-			identifier: method.notFound
-			count: 2
-			path: examples/BucketManagementExample.php
-
-		-
-			message: '#^Call to an undefined method object\:\:postBuckets\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: examples/BucketManagementExample.php
-
-		-
-			message: '#^Cannot call method getOrgs\(\) on object\|string\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: examples/BucketManagementExample.php
-
-		-
-			message: '#^Function findMyOrg\(\) has parameter \$client with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: examples/BucketManagementExample.php
-
-		-
-			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
-			identifier: equal.notAllowed
+			message: '#^Cannot access offset ''org'' on InfluxDB2\\ClientOptions\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
 			count: 1
 			path: examples/BucketManagementExample.php
 
@@ -55,142 +31,16 @@ parameters:
 			path: examples/InvokableScripts.php
 
 		-
-			message: '#^Call to an undefined method object\:\:postDelete\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: examples/QueryExample.php
-
-		-
 			message: '#^Parameter \#1 \$start of method InfluxDB2\\Model\\DeletePredicateRequest\:\:setStart\(\) expects DateTime, DateTime\|false given\.$#'
 			identifier: argument.type
 			count: 1
 			path: examples/QueryExample.php
 
 		-
-			message: '#^Parameter \#1 \$fp of function fclose expects resource, resource\|false given\.$#'
+			message: '#^Parameter \#2 \$length of function fread expects int\<1, max\>, int\<0, max\> given\.$#'
 			identifier: argument.type
 			count: 1
 			path: examples/QueryFromFileExample.php
-
-		-
-			message: '#^Parameter \#1 \$fp of function fread expects resource, resource\|false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: examples/QueryFromFileExample.php
-
-		-
-			message: '#^Parameter \#1 \$query of method InfluxDB2\\QueryApi\:\:query\(\) expects InfluxDB2\\Model\\Query\|string, string\|false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: examples/QueryFromFileExample.php
-
-		-
-			message: '#^Parameter \#2 \$length of function fread expects int\<1, max\>, int\<0, max\>\|false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: examples/QueryFromFileExample.php
-
-		-
-			message: '#^Switch condition type \(int\) does not match case condition "0" \(string\)\.$#'
-			identifier: switch.type
-			count: 1
-			path: examples/QueryFromFileExample.php
-
-		-
-			message: '#^Switch condition type \(int\) does not match case condition "1" \(string\)\.$#'
-			identifier: switch.type
-			count: 1
-			path: examples/QueryFromFileExample.php
-
-		-
-			message: '#^Switch condition type \(int\) does not match case condition "2" \(string\)\.$#'
-			identifier: switch.type
-			count: 1
-			path: examples/QueryFromFileExample.php
-
-		-
-			message: '#^Switch condition type \(int\) does not match case condition "3" \(string\)\.$#'
-			identifier: switch.type
-			count: 1
-			path: examples/QueryFromFileExample.php
-
-		-
-			message: '#^Switch condition type \(int\) does not match case condition "4" \(string\)\.$#'
-			identifier: switch.type
-			count: 1
-			path: examples/QueryFromFileExample.php
-
-		-
-			message: '#^Switch condition type \(int\) does not match case condition "5" \(string\)\.$#'
-			identifier: switch.type
-			count: 1
-			path: examples/QueryFromFileExample.php
-
-		-
-			message: '#^Switch condition type \(int\) does not match case condition "6" \(string\)\.$#'
-			identifier: switch.type
-			count: 1
-			path: examples/QueryFromFileExample.php
-
-		-
-			message: '#^Function checkResult\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: examples/WriteExample.php
-
-		-
-			message: '#^Dead catch \- Exception is never thrown in the try block\.$#'
-			identifier: catch.neverThrown
-			count: 1
-			path: examples/WriteUDPExample.php
-
-		-
-			message: '#^Method InfluxDB2\\BatchItem\:\:__construct\(\) has parameter \$data with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/BatchItem.php
-
-		-
-			message: '#^Method InfluxDB2\\BatchItem\:\:__construct\(\) has parameter \$key with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/BatchItem.php
-
-		-
-			message: '#^Call to an undefined method object\:\:getPingWithHttpInfo\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/InfluxDB2/Client.php
-
-		-
-			message: '#^Method InfluxDB2\\Client\:\:__construct\(\) has parameter \$options with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/InfluxDB2/Client.php
-
-		-
-			message: '#^Method InfluxDB2\\Client\:\:close\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/InfluxDB2/Client.php
-
-		-
-			message: '#^Method InfluxDB2\\Client\:\:createService\(\) has parameter \$serviceClass with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/Client.php
-
-		-
-			message: '#^Method InfluxDB2\\Client\:\:createWriteApi\(\) has parameter \$pointSettings with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/InfluxDB2/Client.php
-
-		-
-			message: '#^Method InfluxDB2\\Client\:\:createWriteApi\(\) has parameter \$writeOptions with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/InfluxDB2/Client.php
 
 		-
 			message: '#^Method InfluxDB2\\Client\:\:ping\(\) return type has no value type specified in iterable type array\.$#'
@@ -199,38 +49,20 @@ parameters:
 			path: src/InfluxDB2/Client.php
 
 		-
-			message: '#^Property InfluxDB2\\Client\:\:\$autoCloseable has no type specified\.$#'
-			identifier: missingType.property
+			message: '#^Method InfluxDB2\\ClientOptionsUdp\:\:toArray\(\) should return array\{udpHost\: string, udpPort\: int\<1, 65535\>, ipVersion\: 4\|6\} but returns array\{udpHost\: string, udpPort\: int, ipVersion\: 4\|6\}\.$#'
+			identifier: return.type
 			count: 1
-			path: src/InfluxDB2/Client.php
+			path: src/InfluxDB2/ClientOptionsUdp.php
 
 		-
-			message: '#^Property InfluxDB2\\Client\:\:\$closed has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/InfluxDB2/Client.php
-
-		-
-			message: '#^Property InfluxDB2\\Client\:\:\$options has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/InfluxDB2/Client.php
-
-		-
-			message: '#^Method InfluxDB2\\DefaultApi\:\:__construct\(\) has parameter \$options with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
+			message: '#^Binary operation "\." between ''allow_redirects\=''\|''bucket\=''\|''debug\=''\|''httpClient\=''\|''ipVersion\=''\|''logFile\=''\|''org\=''\|''precision\=''\|''proxy\=''\|''tags\=''\|''timeout\=''\|''token\=''\|''udpHost\=''\|''udpPort\=''\|''url\=''\|''verifySSL\='' and bool\|int\|Psr\\Http\\Client\\ClientInterface\|string\|null results in an error\.$#'
+			identifier: binaryOp.invalid
 			count: 1
 			path: src/InfluxDB2/DefaultApi.php
 
 		-
-			message: '#^Method InfluxDB2\\DefaultApi\:\:check\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/InfluxDB2/DefaultApi.php
-
-		-
-			message: '#^Method InfluxDB2\\DefaultApi\:\:check\(\) has parameter \$key with no type specified\.$#'
-			identifier: missingType.parameter
+			message: '#^Instanceof between Psr\\Http\\Message\\ResponseInterface and Psr\\Http\\Message\\ResponseInterface will always evaluate to true\.$#'
+			identifier: instanceof.alwaysTrue
 			count: 1
 			path: src/InfluxDB2/DefaultApi.php
 
@@ -241,75 +73,9 @@ parameters:
 			path: src/InfluxDB2/DefaultApi.php
 
 		-
-			message: '#^Method InfluxDB2\\DefaultApi\:\:get\(\) has parameter \$payload with no type specified\.$#'
-			identifier: missingType.parameter
+			message: '#^Parameter \#2 \$array of function implode expects array\<string\>, array\<string, array\<string\>\|bool\|Psr\\Http\\Message\\StreamFactoryInterface\|string\> given\.$#'
+			identifier: argument.type
 			count: 1
-			path: src/InfluxDB2/DefaultApi.php
-
-		-
-			message: '#^Method InfluxDB2\\DefaultApi\:\:get\(\) has parameter \$queryParams with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/DefaultApi.php
-
-		-
-			message: '#^Method InfluxDB2\\DefaultApi\:\:get\(\) has parameter \$uriPath with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/DefaultApi.php
-
-		-
-			message: '#^Method InfluxDB2\\DefaultApi\:\:log\(\) has parameter \$options with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/InfluxDB2/DefaultApi.php
-
-		-
-			message: '#^Method InfluxDB2\\DefaultApi\:\:post\(\) has parameter \$payload with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/DefaultApi.php
-
-		-
-			message: '#^Method InfluxDB2\\DefaultApi\:\:post\(\) has parameter \$queryParams with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/DefaultApi.php
-
-		-
-			message: '#^Method InfluxDB2\\DefaultApi\:\:post\(\) has parameter \$uriPath with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/DefaultApi.php
-
-		-
-			message: '#^Method InfluxDB2\\DefaultApi\:\:request\(\) has parameter \$method with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/DefaultApi.php
-
-		-
-			message: '#^Method InfluxDB2\\DefaultApi\:\:request\(\) has parameter \$payload with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/DefaultApi.php
-
-		-
-			message: '#^Method InfluxDB2\\DefaultApi\:\:request\(\) has parameter \$queryParams with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/DefaultApi.php
-
-		-
-			message: '#^Method InfluxDB2\\DefaultApi\:\:request\(\) has parameter \$uriPath with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/DefaultApi.php
-
-		-
-			message: '#^Only booleans are allowed in a ternary operator condition, Psr\\Http\\Message\\ResponseInterface given\.$#'
-			identifier: ternary.condNotBoolean
-			count: 2
 			path: src/InfluxDB2/DefaultApi.php
 
 		-
@@ -319,176 +85,14 @@ parameters:
 			path: src/InfluxDB2/DefaultApi.php
 
 		-
-			message: '#^Property InfluxDB2\\DefaultApi\:\:\$options has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/InfluxDB2/DefaultApi.php
-
-		-
-			message: '#^Method InfluxDB2\\FluxColumn\:\:__construct\(\) has parameter \$dataType with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/FluxColumn.php
-
-		-
-			message: '#^Method InfluxDB2\\FluxColumn\:\:__construct\(\) has parameter \$defaultValue with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/FluxColumn.php
-
-		-
-			message: '#^Method InfluxDB2\\FluxColumn\:\:__construct\(\) has parameter \$group with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/FluxColumn.php
-
-		-
-			message: '#^Method InfluxDB2\\FluxColumn\:\:__construct\(\) has parameter \$index with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/FluxColumn.php
-
-		-
-			message: '#^Method InfluxDB2\\FluxColumn\:\:__construct\(\) has parameter \$label with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/FluxColumn.php
-
-		-
-			message: '#^Property InfluxDB2\\FluxColumn\:\:\$dataType has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/InfluxDB2/FluxColumn.php
-
-		-
-			message: '#^Property InfluxDB2\\FluxColumn\:\:\$defaultValue has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/InfluxDB2/FluxColumn.php
-
-		-
-			message: '#^Property InfluxDB2\\FluxColumn\:\:\$group has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/InfluxDB2/FluxColumn.php
-
-		-
-			message: '#^Property InfluxDB2\\FluxColumn\:\:\$index has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/InfluxDB2/FluxColumn.php
-
-		-
-			message: '#^Property InfluxDB2\\FluxColumn\:\:\$label has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/InfluxDB2/FluxColumn.php
-
-		-
-			message: '#^Call to function base64_decode\(\) requires parameter \#2 to be set\.$#'
-			identifier: function.strict
-			count: 1
-			path: src/InfluxDB2/FluxCsvParser.php
-
-		-
-			message: '#^Call to function in_array\(\) requires parameter \#3 to be set\.$#'
-			identifier: function.strict
-			count: 1
-			path: src/InfluxDB2/FluxCsvParser.php
-
-		-
 			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
 			identifier: empty.notAllowed
 			count: 2
 			path: src/InfluxDB2/FluxCsvParser.php
 
 		-
-			message: '#^Loose comparison via "\!\=" is not allowed\.$#'
-			identifier: notEqual.notAllowed
-			count: 1
-			path: src/InfluxDB2/FluxCsvParser.php
-
-		-
 			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
 			identifier: equal.notAllowed
-			count: 25
-			path: src/InfluxDB2/FluxCsvParser.php
-
-		-
-			message: '#^Method InfluxDB2\\FluxCsvParser\:\:__construct\(\) has parameter \$response with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/FluxCsvParser.php
-
-		-
-			message: '#^Method InfluxDB2\\FluxCsvParser\:\:addColumnNamesAndTags\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/InfluxDB2/FluxCsvParser.php
-
-		-
-			message: '#^Method InfluxDB2\\FluxCsvParser\:\:addColumnNamesAndTags\(\) has parameter \$csv with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/InfluxDB2/FluxCsvParser.php
-
-		-
-			message: '#^Method InfluxDB2\\FluxCsvParser\:\:addDataTypes\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/InfluxDB2/FluxCsvParser.php
-
-		-
-			message: '#^Method InfluxDB2\\FluxCsvParser\:\:addDataTypes\(\) has parameter \$data_types with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/InfluxDB2/FluxCsvParser.php
-
-		-
-			message: '#^Method InfluxDB2\\FluxCsvParser\:\:addDefaultEmptyValues\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/InfluxDB2/FluxCsvParser.php
-
-		-
-			message: '#^Method InfluxDB2\\FluxCsvParser\:\:addDefaultEmptyValues\(\) has parameter \$defaultValues with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/FluxCsvParser.php
-
-		-
-			message: '#^Method InfluxDB2\\FluxCsvParser\:\:addGroups\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/InfluxDB2/FluxCsvParser.php
-
-		-
-			message: '#^Method InfluxDB2\\FluxCsvParser\:\:addGroups\(\) has parameter \$csv with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/FluxCsvParser.php
-
-		-
-			message: '#^Method InfluxDB2\\FluxCsvParser\:\:closeConnection\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/InfluxDB2/FluxCsvParser.php
-
-		-
-			message: '#^Method InfluxDB2\\FluxCsvParser\:\:each\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/InfluxDB2/FluxCsvParser.php
-
-		-
-			message: '#^Method InfluxDB2\\FluxCsvParser\:\:parse\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/InfluxDB2/FluxCsvParser.php
-
-		-
-			message: '#^Method InfluxDB2\\FluxCsvParser\:\:parseLine\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: src/InfluxDB2/FluxCsvParser.php
 
@@ -499,32 +103,8 @@ parameters:
 			path: src/InfluxDB2/FluxCsvParser.php
 
 		-
-			message: '#^Method InfluxDB2\\FluxCsvParser\:\:parseRecord\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/InfluxDB2/FluxCsvParser.php
-
-		-
-			message: '#^Method InfluxDB2\\FluxCsvParser\:\:parseRecord\(\) has parameter \$csv with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/InfluxDB2/FluxCsvParser.php
-
-		-
-			message: '#^Method InfluxDB2\\FluxCsvParser\:\:parseValues\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/InfluxDB2/FluxCsvParser.php
-
-		-
 			message: '#^Method InfluxDB2\\FluxCsvParser\:\:parseValues\(\) has parameter \$csv with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: src/InfluxDB2/FluxCsvParser.php
-
-		-
-			message: '#^Method InfluxDB2\\FluxCsvParser\:\:stringToStream\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: src/InfluxDB2/FluxCsvParser.php
 
@@ -541,86 +121,14 @@ parameters:
 			path: src/InfluxDB2/FluxCsvParser.php
 
 		-
-			message: '#^Parameter \#1 \$fp of function fwrite expects resource, resource\|false given\.$#'
+			message: '#^Parameter \#1 \$fp of function fgetcsv expects resource, resource\|false given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/InfluxDB2/FluxCsvParser.php
 
 		-
-			message: '#^Parameter \#1 \$fp of function rewind expects resource, resource\|false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/InfluxDB2/FluxCsvParser.php
-
-		-
-			message: '#^Parameter \#2 \$code of class InfluxDB2\\FluxQueryError constructor expects int, int\|string given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/InfluxDB2/FluxCsvParser.php
-
-		-
-			message: '#^Property InfluxDB2\\FluxCsvParser\:\:\$closed has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/InfluxDB2/FluxCsvParser.php
-
-		-
-			message: '#^Property InfluxDB2\\FluxCsvParser\:\:\$groups has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/InfluxDB2/FluxCsvParser.php
-
-		-
-			message: '#^Property InfluxDB2\\FluxCsvParser\:\:\$parsingStateError has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/InfluxDB2/FluxCsvParser.php
-
-		-
-			message: '#^Property InfluxDB2\\FluxCsvParser\:\:\$resource has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/InfluxDB2/FluxCsvParser.php
-
-		-
-			message: '#^Property InfluxDB2\\FluxCsvParser\:\:\$response has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/InfluxDB2/FluxCsvParser.php
-
-		-
-			message: '#^Property InfluxDB2\\FluxCsvParser\:\:\$responseMode has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/InfluxDB2/FluxCsvParser.php
-
-		-
-			message: '#^Property InfluxDB2\\FluxCsvParser\:\:\$startNewTable has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/InfluxDB2/FluxCsvParser.php
-
-		-
-			message: '#^Property InfluxDB2\\FluxCsvParser\:\:\$stream has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/InfluxDB2/FluxCsvParser.php
-
-		-
-			message: '#^Property InfluxDB2\\FluxCsvParser\:\:\$tableId has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/InfluxDB2/FluxCsvParser.php
-
-		-
-			message: '#^Property InfluxDB2\\FluxCsvParser\:\:\$tableIndex has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/InfluxDB2/FluxCsvParser.php
-
-		-
-			message: '#^Property InfluxDB2\\FluxCsvParser\:\:\$tables has no type specified\.$#'
-			identifier: missingType.property
+			message: '#^Property InfluxDB2\\FluxCsvParser\:\:\$tables type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/InfluxDB2/FluxCsvParser.php
 
@@ -631,58 +139,10 @@ parameters:
 			path: src/InfluxDB2/FluxRecord.php
 
 		-
-			message: '#^Method InfluxDB2\\FluxRecord\:\:__construct\(\) has parameter \$row with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/FluxRecord.php
-
-		-
-			message: '#^Method InfluxDB2\\FluxRecord\:\:__construct\(\) has parameter \$table with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/FluxRecord.php
-
-		-
-			message: '#^Method InfluxDB2\\FluxRecord\:\:__construct\(\) has parameter \$values with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/FluxRecord.php
-
-		-
 			message: '#^PHPDoc tag @return with type mixed is not subtype of native type string\.$#'
 			identifier: return.phpDocType
 			count: 1
 			path: src/InfluxDB2/FluxRecord.php
-
-		-
-			message: '#^Property InfluxDB2\\FluxRecord\:\:\$row has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/InfluxDB2/FluxRecord.php
-
-		-
-			message: '#^Property InfluxDB2\\FluxRecord\:\:\$table has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/InfluxDB2/FluxRecord.php
-
-		-
-			message: '#^Property InfluxDB2\\FluxRecord\:\:\$values has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/InfluxDB2/FluxRecord.php
-
-		-
-			message: '#^Method InfluxDB2\\FluxTable\:\:getGroupKey\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/InfluxDB2/FluxTable.php
-
-		-
-			message: '#^Method InfluxDB2\\HealthApi\:\:__construct\(\) has parameter \$options with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/InfluxDB2/HealthApi.php
 
 		-
 			message: '#^Method InfluxDB2\\HealthApi\:\:health\(\) should return InfluxDB2\\Model\\HealthCheck but returns array\|object\|null\.$#'
@@ -691,26 +151,14 @@ parameters:
 			path: src/InfluxDB2/HealthApi.php
 
 		-
-			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
-			identifier: equal.notAllowed
+			message: '#^Call to an undefined method object\:\:getScripts\(\)\.$#'
+			identifier: method.notFound
 			count: 1
-			path: src/InfluxDB2/Internal/DebugHttpPlugin.php
+			path: src/InfluxDB2/InvokableScriptsApi.php
 
 		-
-			message: '#^Method InfluxDB2\\Internal\\DebugHttpPlugin\:\:__construct\(\) has parameter \$options with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/InfluxDB2/Internal/DebugHttpPlugin.php
-
-		-
-			message: '#^Property InfluxDB2\\Internal\\DebugHttpPlugin\:\:\$options has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/InfluxDB2/Internal/DebugHttpPlugin.php
-
-		-
-			message: '#^Method InfluxDB2\\InvokableScriptsApi\:\:__construct\(\) has parameter \$options with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
+			message: '#^Method InfluxDB2\\InvokableScriptsApi\:\:createScript\(\) should return InfluxDB2\\Model\\Script but returns object\.$#'
+			identifier: return.type
 			count: 1
 			path: src/InfluxDB2/InvokableScriptsApi.php
 
@@ -721,116 +169,14 @@ parameters:
 			path: src/InfluxDB2/InvokableScriptsApi.php
 
 		-
-			message: '#^Property InfluxDB2\\InvokableScriptsApi\:\:\$service has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/InfluxDB2/InvokableScriptsApi.php
-
-		-
-			message: '#^Method InfluxDB2\\PointSettings\:\:__construct\(\) has parameter \$defaultTags with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/InfluxDB2/PointSettings.php
-
-		-
-			message: '#^Method InfluxDB2\\PointSettings\:\:addDefaultTag\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/InfluxDB2/PointSettings.php
-
-		-
-			message: '#^Method InfluxDB2\\PointSettings\:\:getDefaultTags\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/InfluxDB2/PointSettings.php
-
-		-
 			message: '#^Method InfluxDB2\\PointSettings\:\:getValue\(\) should return string but returns string\|false\.$#'
 			identifier: return.type
 			count: 1
 			path: src/InfluxDB2/PointSettings.php
 
 		-
-			message: '#^Property InfluxDB2\\PointSettings\:\:\$defaultTags has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/InfluxDB2/PointSettings.php
-
-		-
-			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
-			identifier: equal.notAllowed
-			count: 4
-			path: src/InfluxDB2/QueryApi.php
-
-		-
-			message: '#^Method InfluxDB2\\QueryApi\:\:__construct\(\) has parameter \$options with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/InfluxDB2/QueryApi.php
-
-		-
-			message: '#^Method InfluxDB2\\QueryApi\:\:generatePayload\(\) has parameter \$dialect with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/QueryApi.php
-
-		-
-			message: '#^Method InfluxDB2\\QueryApi\:\:generatePayload\(\) has parameter \$query with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/QueryApi.php
-
-		-
-			message: '#^Method InfluxDB2\\QueryApi\:\:postQuery\(\) has parameter \$dialect with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/QueryApi.php
-
-		-
-			message: '#^Method InfluxDB2\\QueryApi\:\:postQuery\(\) has parameter \$org with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/QueryApi.php
-
-		-
-			message: '#^Method InfluxDB2\\QueryApi\:\:postQuery\(\) has parameter \$query with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/QueryApi.php
-
-		-
-			message: '#^Property InfluxDB2\\QueryApi\:\:\$DEFAULT_DIALECT has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/InfluxDB2/QueryApi.php
-
-		-
-			message: '#^Short ternary operator is not allowed\. Use null coalesce operator if applicable or consider using long ternary\.$#'
-			identifier: ternary.shortNotAllowed
-			count: 4
-			path: src/InfluxDB2/QueryApi.php
-
-		-
 			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
 			identifier: empty.notAllowed
-			count: 4
-			path: src/InfluxDB2/UdpWriter.php
-
-		-
-			message: '#^Method InfluxDB2\\UdpWriter\:\:__construct\(\) has parameter \$options with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/InfluxDB2/UdpWriter.php
-
-		-
-			message: '#^Method InfluxDB2\\UdpWriter\:\:close\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/InfluxDB2/UdpWriter.php
-
-		-
-			message: '#^Method InfluxDB2\\UdpWriter\:\:write\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: src/InfluxDB2/UdpWriter.php
 
@@ -841,46 +187,10 @@ parameters:
 			path: src/InfluxDB2/UdpWriter.php
 
 		-
-			message: '#^Only booleans are allowed in an if condition, resource\|false given\.$#'
-			identifier: if.condNotBoolean
-			count: 1
-			path: src/InfluxDB2/UdpWriter.php
-
-		-
-			message: '#^Property InfluxDB2\\UdpWriter\:\:\$options has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/InfluxDB2/UdpWriter.php
-
-		-
-			message: '#^Property InfluxDB2\\UdpWriter\:\:\$socket \(resource\) does not accept null\.$#'
+			message: '#^Property InfluxDB2\\UdpWriter\:\:\$socket \(resource\|null\) does not accept resource\|false\.$#'
 			identifier: assign.propertyType
 			count: 1
 			path: src/InfluxDB2/UdpWriter.php
-
-		-
-			message: '#^Property InfluxDB2\\UdpWriter\:\:\$socket \(resource\) does not accept resource\|false\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: src/InfluxDB2/UdpWriter.php
-
-		-
-			message: '#^Property InfluxDB2\\UdpWriter\:\:\$socket \(resource\) in empty\(\) is not falsy\.$#'
-			identifier: empty.property
-			count: 1
-			path: src/InfluxDB2/UdpWriter.php
-
-		-
-			message: '#^Property InfluxDB2\\UdpWriter\:\:\$socket \(resource\) in isset\(\) is not nullable\.$#'
-			identifier: isset.property
-			count: 1
-			path: src/InfluxDB2/UdpWriter.php
-
-		-
-			message: '#^Call to function array_search\(\) requires parameter \#3 to be set\.$#'
-			identifier: function.strict
-			count: 1
-			path: src/InfluxDB2/Worker.php
 
 		-
 			message: '#^Construct empty\(\) is not allowed\. Use more strict comparison\.$#'
@@ -889,128 +199,20 @@ parameters:
 			path: src/InfluxDB2/Worker.php
 
 		-
-			message: '#^Loose comparison via "\!\=" is not allowed\.$#'
-			identifier: notEqual.notAllowed
-			count: 2
-			path: src/InfluxDB2/Worker.php
-
-		-
-			message: '#^Method InfluxDB2\\Worker\:\:__construct\(\) has parameter \$client with no type specified\.$#'
-			identifier: missingType.parameter
+			message: '#^Parameter \#1 \$data of method InfluxDB2\\Worker\:\:write\(\) expects array\<int, array\{key\: InfluxDB2\\BatchItemKey, data\: list\<string\>\}\>, non\-empty\-array\<int, array\{key\?\: InfluxDB2\\BatchItemKey, data\: non\-empty\-list\<string\>\}\> given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/InfluxDB2/Worker.php
 
 		-
-			message: '#^Method InfluxDB2\\Worker\:\:checkBackgroundQueue\(\) has no return type specified\.$#'
-			identifier: missingType.return
+			message: '#^Parameter \#2 \$data of method InfluxDB2\\Worker\:\:existsKey\(\) expects array\<int, array\{key\: InfluxDB2\\BatchItemKey, data\: list\<string\>\}\>, array\<int, array\{key\?\: InfluxDB2\\BatchItemKey, data\: list\<string\>\}\> given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/InfluxDB2/Worker.php
 
 		-
-			message: '#^Method InfluxDB2\\Worker\:\:existsKey\(\) has parameter \$data with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/Worker.php
-
-		-
-			message: '#^Method InfluxDB2\\Worker\:\:existsKey\(\) has parameter \$key with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/Worker.php
-
-		-
-			message: '#^Method InfluxDB2\\Worker\:\:existsKey\(\) should return int\|null but returns int\|string\|false\.$#'
-			identifier: return.type
-			count: 1
-			path: src/InfluxDB2/Worker.php
-
-		-
-			message: '#^Method InfluxDB2\\Worker\:\:flush\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/InfluxDB2/Worker.php
-
-		-
-			message: '#^Method InfluxDB2\\Worker\:\:push\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/InfluxDB2/Worker.php
-
-		-
-			message: '#^Method InfluxDB2\\Worker\:\:push\(\) has parameter \$payload with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/Worker.php
-
-		-
-			message: '#^Method InfluxDB2\\Worker\:\:write\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/InfluxDB2/Worker.php
-
-		-
-			message: '#^Method InfluxDB2\\Worker\:\:write\(\) has parameter \$data with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/Worker.php
-
-		-
-			message: '#^Property InfluxDB2\\Worker\:\:\$queue has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/InfluxDB2/Worker.php
-
-		-
-			message: '#^Property InfluxDB2\\Worker\:\:\$writeOptions has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/InfluxDB2/Worker.php
-
-		-
-			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
-			identifier: equal.notAllowed
-			count: 2
-			path: src/InfluxDB2/WriteApi.php
-
-		-
-			message: '#^Method InfluxDB2\\WriteApi\:\:__construct\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			message: '#^Method InfluxDB2\\WriteApi\:\:addDefaultTags\(\) has parameter \$data with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: src/InfluxDB2/WriteApi.php
-
-		-
-			message: '#^Method InfluxDB2\\WriteApi\:\:__construct\(\) has parameter \$pointSettings with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/InfluxDB2/WriteApi.php
-
-		-
-			message: '#^Method InfluxDB2\\WriteApi\:\:__construct\(\) has parameter \$writeOptions with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/InfluxDB2/WriteApi.php
-
-		-
-			message: '#^Method InfluxDB2\\WriteApi\:\:addDefaultTags\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/InfluxDB2/WriteApi.php
-
-		-
-			message: '#^Method InfluxDB2\\WriteApi\:\:addDefaultTags\(\) has parameter \$data with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/InfluxDB2/WriteApi.php
-
-		-
-			message: '#^Method InfluxDB2\\WriteApi\:\:close\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/InfluxDB2/WriteApi.php
-
-		-
-			message: '#^Method InfluxDB2\\WriteApi\:\:write\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: src/InfluxDB2/WriteApi.php
 
@@ -1021,25 +223,7 @@ parameters:
 			path: src/InfluxDB2/WriteApi.php
 
 		-
-			message: '#^Method InfluxDB2\\WriteApi\:\:writeRaw\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/InfluxDB2/WriteApi.php
-
-		-
-			message: '#^Parameter \#1 \$data of method InfluxDB2\\WriteApi\:\:writeRaw\(\) expects string, InfluxDB2\\BatchItem\|string given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/InfluxDB2/WriteApi.php
-
-		-
-			message: '#^Parameter \#1 \$key of method InfluxDB2\\Point\:\:addTag\(\) expects string, int\|string given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/InfluxDB2/WriteApi.php
-
-		-
-			message: '#^Parameter \#1 \$key of method InfluxDB2\\PointSettings\:\:addDefaultTag\(\) expects string, int\|string given\.$#'
+			message: '#^Parameter \#1 \$data of method InfluxDB2\\WriteApi\:\:addDefaultTags\(\) expects array\|InfluxDB2\\Point, array\|InfluxDB2\\Point\|string given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/InfluxDB2/WriteApi.php
@@ -1049,96 +233,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: src/InfluxDB2/WriteApi.php
-
-		-
-			message: '#^Property InfluxDB2\\WriteApi\:\:\$closed has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/InfluxDB2/WriteApi.php
-
-		-
-			message: '#^Property InfluxDB2\\WriteApi\:\:\$pointSettings has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/InfluxDB2/WriteApi.php
-
-		-
-			message: '#^Property InfluxDB2\\WriteApi\:\:\$worker \(InfluxDB2\\Worker\) in isset\(\) is not nullable\.$#'
-			identifier: isset.property
-			count: 2
-			path: src/InfluxDB2/WriteApi.php
-
-		-
-			message: '#^Property InfluxDB2\\WriteApi\:\:\$writeOptions has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/InfluxDB2/WriteApi.php
-
-		-
-			message: '#^Short ternary operator is not allowed\. Use null coalesce operator if applicable or consider using long ternary\.$#'
-			identifier: ternary.shortNotAllowed
-			count: 2
-			path: src/InfluxDB2/WriteApi.php
-
-		-
-			message: '#^Ternary operator condition is always true\.$#'
-			identifier: ternary.alwaysTrue
-			count: 2
-			path: src/InfluxDB2/WriteApi.php
-
-		-
-			message: '#^Method InfluxDB2\\WriteOptions\:\:__construct\(\) has parameter \$writeOptions with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/InfluxDB2/WriteOptions.php
-
-		-
-			message: '#^Property InfluxDB2\\WriteOptions\:\:\$batchSize has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/InfluxDB2/WriteOptions.php
-
-		-
-			message: '#^Property InfluxDB2\\WriteOptions\:\:\$exponentialBase has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/InfluxDB2/WriteOptions.php
-
-		-
-			message: '#^Property InfluxDB2\\WriteOptions\:\:\$jitterInterval has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/InfluxDB2/WriteOptions.php
-
-		-
-			message: '#^Property InfluxDB2\\WriteOptions\:\:\$maxRetries has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/InfluxDB2/WriteOptions.php
-
-		-
-			message: '#^Property InfluxDB2\\WriteOptions\:\:\$maxRetryDelay has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/InfluxDB2/WriteOptions.php
-
-		-
-			message: '#^Property InfluxDB2\\WriteOptions\:\:\$maxRetryTime has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/InfluxDB2/WriteOptions.php
-
-		-
-			message: '#^Property InfluxDB2\\WriteOptions\:\:\$retryInterval has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/InfluxDB2/WriteOptions.php
-
-		-
-			message: '#^Property InfluxDB2\\WriteOptions\:\:\$writeType has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/InfluxDB2/WriteOptions.php
 
 		-
 			message: '#^Binary operation "\." between InfluxDB2\\BatchItem\|string\|null and "\\n" results in an error\.$#'
@@ -1153,56 +247,14 @@ parameters:
 			path: src/InfluxDB2/WritePayloadSerializer.php
 
 		-
-			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
-			identifier: equal.notAllowed
-			count: 2
-			path: src/InfluxDB2/WritePayloadSerializer.php
-
-		-
 			message: '#^Method InfluxDB2\\WritePayloadSerializer\:\:generatePayload\(\) has parameter \$data with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/InfluxDB2/WritePayloadSerializer.php
 
 		-
-			message: '#^Variable \$payload in isset\(\) always exists and is not nullable\.$#'
-			identifier: isset.variable
-			count: 1
-			path: src/InfluxDB2/WritePayloadSerializer.php
-
-		-
-			message: '#^Loose comparison via "\!\=" is not allowed\.$#'
-			identifier: notEqual.notAllowed
-			count: 1
-			path: src/InfluxDB2/WriteRetry.php
-
-		-
-			message: '#^Loose comparison via "\=\=" is not allowed\.$#'
-			identifier: equal.notAllowed
-			count: 1
-			path: src/InfluxDB2/WriteRetry.php
-
-		-
-			message: '#^Method InfluxDB2\\WriteRetry\:\:__construct\(\) has parameter \$options with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/InfluxDB2/WriteRetry.php
-
-		-
-			message: '#^Method InfluxDB2\\WriteRetry\:\:getBackoffTime\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/InfluxDB2/WriteRetry.php
-
-		-
 			message: '#^Method InfluxDB2\\WriteRetry\:\:retry\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: src/InfluxDB2/WriteRetry.php
-
-		-
-			message: '#^Method InfluxDB2\\WriteRetry\:\:retry\(\) has parameter \$attempts with no type specified\.$#'
-			identifier: missingType.parameter
 			count: 1
 			path: src/InfluxDB2/WriteRetry.php
 
@@ -1213,130 +265,16 @@ parameters:
 			path: src/InfluxDB2/WriteRetry.php
 
 		-
-			message: '#^Property InfluxDB2\\WriteRetry\:\:\$exponentialBase has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/InfluxDB2/WriteRetry.php
-
-		-
-			message: '#^Property InfluxDB2\\WriteRetry\:\:\$jitterInterval has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/InfluxDB2/WriteRetry.php
-
-		-
-			message: '#^Property InfluxDB2\\WriteRetry\:\:\$maxRetries has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/InfluxDB2/WriteRetry.php
-
-		-
-			message: '#^Property InfluxDB2\\WriteRetry\:\:\$maxRetryDelay has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/InfluxDB2/WriteRetry.php
-
-		-
-			message: '#^Property InfluxDB2\\WriteRetry\:\:\$maxRetryTime has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/InfluxDB2/WriteRetry.php
-
-		-
-			message: '#^Property InfluxDB2\\WriteRetry\:\:\$options type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/InfluxDB2/WriteRetry.php
-
-		-
-			message: '#^Property InfluxDB2\\WriteRetry\:\:\$retryInterval has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/InfluxDB2/WriteRetry.php
-
-		-
-			message: '#^Property InfluxDB2\\WriteRetry\:\:\$retryTimout has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/InfluxDB2/WriteRetry.php
-
-		-
-			message: '#^Method InfluxDB2\\Writer\:\:write\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/InfluxDB2/Writer.php
-
-		-
 			message: '#^Method InfluxDB2\\Writer\:\:write\(\) has parameter \$data with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/InfluxDB2/Writer.php
 
 		-
-			message: '#^Property InfluxDB2Test\\BasicTest\:\:\$requests \(array\<int, array\{request\: GuzzleHttp\\Psr7\\Request, response\: GuzzleHttp\\Psr7\\Response, error\: mixed, options\: array\<mixed\>\}\>\) does not accept array\|ArrayAccess\<int, array\>\.$#'
+			message: '#^Property InfluxDB2Test\\BasicTest\:\:\$requests \(array\<int, array\{request\: Psr\\Http\\Message\\RequestInterface, response\: Psr\\Http\\Message\\ResponseInterface\|null, error\: mixed, options\: array\<mixed\>\}\>\) does not accept array\<array\{request\: Psr\\Http\\Message\\RequestInterface, response\: Psr\\Http\\Message\\ResponseInterface\|null, error\: mixed, options\: array\<mixed\>\}\>\|ArrayAccess\<int, array\{request\: Psr\\Http\\Message\\RequestInterface, response\: Psr\\Http\\Message\\ResponseInterface\|null, error\: mixed, options\: array\<mixed\>\}\>\.$#'
 			identifier: assign.propertyType
 			count: 1
 			path: tests/BasicTest.php
-
-		-
-			message: '#^Offset ''uri'' might not exist on array\{timed_out\: bool, blocked\: bool, eof\: bool, unread_bytes\: int, stream_type\: string, wrapper_type\: string, wrapper_data\: mixed, mode\: string, \.\.\.\}\.$#'
-			identifier: offsetAccess.notFound
-			count: 1
-			path: tests/ClientTest.php
-
-		-
-			message: '#^Parameter \#2 \$haystack of static method PHPUnit\\Framework\\Assert\:\:assertStringContainsString\(\) expects string, string\|false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: tests/ClientTest.php
-
-		-
-			message: '#^Call to an undefined method object\:\:getConfig\(\)\.$#'
-			identifier: method.notFound
-			count: 2
-			path: tests/DefaultApiTest.php
-
-		-
-			message: '#^Method InfluxDB2Test\\FluxCsvParserTest\:\:assertColumns\(\) has parameter \$columnHeaders with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: tests/FluxCsvParserTest.php
-
-		-
-			message: '#^Method InfluxDB2Test\\FluxCsvParserTest\:\:assertColumns\(\) has parameter \$values with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: tests/FluxCsvParserTest.php
-
-		-
-			message: '#^Method InfluxDB2Test\\FluxCsvParserTest\:\:assertMultipleRecords\(\) has parameter \$tables with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: tests/FluxCsvParserTest.php
-
-		-
-			message: '#^Call to an undefined method object\:\:getBuckets\(\)\.$#'
-			identifier: method.notFound
-			count: 2
-			path: tests/ITBucketServiceTest.php
-
-		-
-			message: '#^Call to an undefined method object\:\:getHealth\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: tests/ITBucketServiceTest.php
-
-		-
-			message: '#^Call to an undefined method object\:\:getId\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: tests/ITBucketServiceTest.php
-
-		-
-			message: '#^Call to an undefined method object\:\:getName\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: tests/ITBucketServiceTest.php
 
 		-
 			message: '#^Parameter object of print cannot be converted to string\.$#'
@@ -1345,28 +283,34 @@ parameters:
 			path: tests/ITBucketServiceTest.php
 
 		-
-			message: '#^Call to an undefined method object\:\:getName\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: tests/ITTaskServiceTest.php
-
-		-
-			message: '#^Cannot call method getUsers\(\) on InfluxDB2\\Model\\Error\|InfluxDB2\\Model\\Users\|string\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: tests/ITUsersServiceTest.php
-
-		-
-			message: '#^Cannot call method getOrgs\(\) on object\|string\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: tests/IntegrationBaseTestCase.php
-
-		-
 			message: '#^Offset ''org'' might not exist on array\{url\: string, token\: string, bucket\?\: string, org\?\: string, precision\?\: ''ms''\|''ns''\|''s''\|''us'', allow_redirects\?\: bool, debug\?\: bool, logFile\?\: string, \.\.\.\}\.$#'
 			identifier: offsetAccess.notFound
 			count: 1
 			path: tests/IntegrationBaseTestCase.php
+
+		-
+			message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) with ''InfluxDB2\\\\InvokableScriptsApi'' and InfluxDB2\\InvokableScriptsApi will always evaluate to true\.$#'
+			identifier: staticMethod.alreadyNarrowedType
+			count: 1
+			path: tests/InvokableScriptsApiTest.php
+
+		-
+			message: '''
+				#^Call to deprecated method expectWarning\(\) of class PHPUnit\\Framework\\TestCase\:
+				https\://github\.com/sebastianbergmann/phpunit/issues/5062$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: tests/PointTest.php
+
+		-
+			message: '''
+				#^Call to deprecated method expectWarningMessage\(\) of class PHPUnit\\Framework\\TestCase\:
+				https\://github\.com/sebastianbergmann/phpunit/issues/5062$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: tests/PointTest.php
 
 		-
 			message: '#^Parameter \#1 \$data of static method InfluxDB2\\Point\:\:fromArray\(\) expects array\{name\: string, tags\?\: array\<string, string\|Stringable\>, fields\?\: array\<string, bool\|float\|int\|string\|null\>, time\?\: DateTimeInterface\|float\|int\|null, precision\?\: ''ms''\|''ns''\|''s''\|''us''\|null\}, array\{tags\: array\{host\: ''aws'', region\: ''us''\}, fields\: array\{level\: 5, saturation\: ''99%%''\}, time\: 123\} given\.$#'
@@ -1407,12 +351,6 @@ parameters:
 		-
 			message: '#^Call to static method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) with ''Psr\\\\Http\\\\Message\\\\RequestInterface'' and null will always evaluate to false\.$#'
 			identifier: staticMethod.impossibleType
-			count: 1
-			path: tests/WriteApiBatchingTest.php
-
-		-
-			message: '#^Parameter \#2 \$haystack of static method PHPUnit\\Framework\\Assert\:\:assertStringContainsString\(\) expects string, string\|false given\.$#'
-			identifier: argument.type
 			count: 1
 			path: tests/WriteApiBatchingTest.php
 

--- a/src/InfluxDB2/ApiException.php
+++ b/src/InfluxDB2/ApiException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * ApiException
  * PHP version 5
@@ -41,7 +42,6 @@ use RuntimeException;
  */
 class ApiException extends RuntimeException
 {
-
     /**
      * The HTTP body of the server response either as Json or string.
      *

--- a/src/InfluxDB2/BatchItem.php
+++ b/src/InfluxDB2/BatchItem.php
@@ -7,12 +7,10 @@ namespace InfluxDB2;
  */
 class BatchItem
 {
-    /** @var BatchItemKey */
-    public $key;
-    /** @var string */
-    public $data;
+    public BatchItemKey $key;
+    public string $data;
 
-    public function __construct($key, $data)
+    public function __construct(BatchItemKey $key, string $data)
     {
         $this->key  = $key;
         $this->data = $data;

--- a/src/InfluxDB2/BatchItemKey.php
+++ b/src/InfluxDB2/BatchItemKey.php
@@ -9,12 +9,10 @@ use InfluxDB2\Model\WritePrecision;
  */
 class BatchItemKey
 {
-    /** @var string */
-    public $bucket;
-    /** @var string */
-    public $org;
+    public string $bucket;
+    public string $org;
     /** @var WritePrecision::S|WritePrecision::MS|WritePrecision::US|WritePrecision::NS|null */
-    public $precision;
+    public ?string $precision;
 
     /**
      * @param string $bucket

--- a/src/InfluxDB2/Client.php
+++ b/src/InfluxDB2/Client.php
@@ -4,6 +4,7 @@ namespace InfluxDB2;
 
 use Exception;
 use InfluxDB2\Model\HealthCheck;
+use InfluxDB2\Model\WritePrecision;
 use InfluxDB2\Service\InvokableScriptsService;
 use InfluxDB2\Service\PingService;
 use ReflectionClass;
@@ -15,11 +16,12 @@ class Client
     /**
      * Client version updated by: 'make release VERSION=1.5.0'
      */
-    const VERSION = 'dev';
+    public const VERSION = 'dev';
 
-    public $options;
-    public $closed = false;
-    private $autoCloseable = array();
+    public ClientOptions $options;
+    public bool $closed = false;
+    /** @var array<WriteApi> */
+    private array $autoCloseable = array();
 
     /**
      * Client constructor.
@@ -56,11 +58,31 @@ class Client
      * - allow_redirects: Describes the redirect behavior for requests.
      * - ipVersion: Specifies which version of IP to use, supports 4 and 6 as possible values (UDP Writer).
      *
-     * @param array $options
+     * @param array{
+     *      url: string,
+     *      token: string,
+     *      bucket?: string,
+     *      org?: string,
+     *      precision?: WritePrecision::S|WritePrecision::MS|WritePrecision::US|WritePrecision::NS,
+     *      allow_redirects?: bool,
+     *      debug?: bool,
+     *      logFile?: string,
+     *      httpClient?: \Psr\Http\Client\ClientInterface,
+     *      verifySSL?: bool,
+     *      timeout?: int,
+     *      proxy?: string,
+     *      udpHost?: string,
+     *      udpPort?: int<1, 65535>,
+     *      ipVersion?: 4|6,
+     *      tags?: array<string, string>,
+     *  }|ClientOptions $options Client options
      */
-    public function __construct(array $options)
+    public function __construct($options)
     {
-        $this->options = $options;
+        if (!is_array($options) && !$options instanceof ClientOptions) {
+            throw new \InvalidArgumentException('Options must be an array or ClientOptions');
+        }
+        $this->options = is_array($options) ? ClientOptions::fromArray($options) : $options;
     }
 
     /**
@@ -69,8 +91,17 @@ class Client
      *          'writeType' => methods of write (WriteType::SYNCHRONOUS - default, WriteType::BATCHING)
      *          'batchSize' => the number of data point to collect in batch
      *      ]
-     * @param array|null $writeOptions Array containing the write parameters (See above)
-     * @param array|null $pointSettings Array of default tags
+     * @param array{
+     *      writeType?: WriteType::SYNCHRONOUS|WriteType::BATCHING,
+     *      batchSize?: int,
+     *      retryInterval?: int,
+     *      maxRetries?: int,
+     *      maxRetryDelay?: int,
+     *      maxRetryTime?: int,
+     *      exponentialBase?: int,
+     *      jitterInterval?: int,
+     *  }|null $writeOptions Array containing the write parameters (See above)
+     * @param array<string, string>|null $pointSettings Array of default tags
      * @return WriteApi
      */
     public function createWriteApi(?array $writeOptions = null, ?array $pointSettings = null): WriteApi
@@ -86,6 +117,9 @@ class Client
      */
     public function createUdpWriter(): UdpWriter
     {
+        if ($this->options->udp === null) {
+            throw new Exception('UDP options are not set');
+        }
         return new UdpWriter($this->options);
     }
 
@@ -137,7 +171,7 @@ class Client
     /**
      * Close all connections into InfluxDB
      */
-    public function close()
+    public function close(): void
     {
         $this->closed = true;
 
@@ -150,10 +184,11 @@ class Client
     /**
      * Creates the instance of api service
      *
-     * @param  $serviceClass
-     * @return object service instance
+     * @template C of object
+     * @param class-string<C> $serviceClass
+     * @return C service instance
      */
-    public function createService($serviceClass)
+    public function createService(string $serviceClass): object
     {
         try {
             $class = new ReflectionClass($serviceClass);

--- a/src/InfluxDB2/ClientOptions.php
+++ b/src/InfluxDB2/ClientOptions.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace InfluxDB2;
+
+use InfluxDB2\Model\WritePrecision;
+use InvalidArgumentException;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+
+class ClientOptions
+{
+    public string $url;
+    public string $token;
+    public ?string $bucket;
+    public ?string $org;
+    /** @var WritePrecision::S|WritePrecision::MS|WritePrecision::US|WritePrecision::NS|null $precision */
+    public ?string $precision;
+    /** @var array{
+     *     'preserve_header'?: bool|string[],
+     *     'use_default_for_multiple'?: bool,
+     *     'strict'?: bool,
+     *     'stream_factory'?:StreamFactoryInterface,
+     * }|bool|null $allowRedirects */
+    public $allowRedirects;
+    public ?bool $debug;
+    public ?string $logFile;
+    public ?ClientInterface $httpClient;
+    public ?bool $verifySSL;
+    public ?int $timeout;
+    public ?string $proxy;
+    public ?ClientOptionsUdp $udp;
+    /** @var array<string, string>|null $tags */
+    public ?array $tags;
+
+    public function __construct(
+        string $url,
+        string $token
+    ) {
+        $this->url = $url;
+        $this->token = $token;
+    }
+
+    /**
+     * @param array{
+     *     url: string,
+     *     token: string,
+     *     bucket?: string,
+     *     org?: string,
+     *     precision?: WritePrecision::S|WritePrecision::MS|WritePrecision::US|WritePrecision::NS,
+     *     allow_redirects?: array{
+     *         'preserve_header'?: bool|string[],
+     *         'use_default_for_multiple'?: bool,
+     *         'strict'?: bool,
+     *         'stream_factory'?: StreamFactoryInterface,
+     *     }|bool,
+     *     debug?: bool,
+     *     logFile?: string,
+     *     httpClient?: ClientInterface,
+     *     verifySSL?: bool,
+     *     timeout?: int,
+     *     proxy?: string,
+     *     udpHost?: string,
+     *     udpPort?: int<1, 65535>,
+     *     ipVersion?: 4|6,
+     *     tags?: array<string, string>,
+     * } $options
+     */
+    public static function fromArray(array $options): self
+    {
+        if (
+            !array_key_exists('url', $options) ||
+            !is_string($options['url']) ||
+            filter_var($options['url'], FILTER_VALIDATE_URL) === false
+        ) {
+            throw new InvalidArgumentException('url is required and must be a string');
+        }
+        if (
+            !array_key_exists('token', $options) ||
+            !is_string($options['token'])
+        ) {
+            throw new InvalidArgumentException('token is required and must be a string');
+        }
+        if (
+            array_key_exists('precision', $options) &&
+            !in_array($options['precision'], WritePrecision::getAllowableEnumValues(), true)
+        ) {
+            throw new InvalidArgumentException('precision must be a valid WritePrecision value');
+        }
+        if (
+            array_key_exists('httpClient', $options) &&
+            !($options['httpClient'] instanceof ClientInterface)
+        ) {
+            throw new InvalidArgumentException('httpClient must be an instance of Psr\Http\Client\ClientInterface');
+        }
+        if (
+            array_key_exists('ipVersion', $options) &&
+            !in_array($options['ipVersion'], [4, 6], true)
+        ) {
+            throw new InvalidArgumentException('ipVersion must be 4, 6');
+        }
+        $clientOptions = new self(
+            $options['url'],
+            $options['token'],
+        );
+        $clientOptions->bucket = $options['bucket'] ?? null;
+        $clientOptions->org = $options['org'] ?? null;
+        $clientOptions->precision = $options['precision'] ?? null;
+        $clientOptions->allowRedirects = $options['allow_redirects'] ?? null;
+        $clientOptions->debug = $options['debug'] ?? null;
+        $clientOptions->logFile = $options['logFile'] ?? null;
+        $clientOptions->httpClient = $options['httpClient'] ?? null;
+        $clientOptions->verifySSL = $options['verifySSL'] ?? null;
+        $clientOptions->timeout = $options['timeout'] ?? null;
+        $clientOptions->proxy = $options['proxy'] ?? null;
+        if (array_key_exists('udpPort', $options)) {
+            $clientOptions->udp = ClientOptionsUdp::fromArray($options);
+        } else {
+            $clientOptions->udp = null;
+        }
+        $clientOptions->tags = $options['tags'] ?? null;
+        return $clientOptions;
+    }
+
+    /**
+     * @return array{
+     *     url: string,
+     *     token: string,
+     *     bucket?: string,
+     *     org?: string,
+     *     precision?: WritePrecision::S|WritePrecision::MS|WritePrecision::US|WritePrecision::NS,
+     *     allow_redirects?: array{
+     *         'preserve_header'?: bool|string[],
+     *         'use_default_for_multiple'?: bool,
+     *         'strict'?: bool,
+     *         'stream_factory'?: StreamFactoryInterface,
+     *     }|bool|null,
+     *     debug?: bool,
+     *     logFile?: string,
+     *     httpClient?: ClientInterface,
+     *     verifySSL?: bool,
+     *     timeout?: int,
+     *     proxy?: string,
+     *     udpHost?: string,
+     *     udpPort?: int<1, 65535>,
+     *     ipVersion?: 4|6,
+     *     tags?: array<string, string>,
+     * }
+     */
+    public function toArray(): array
+    {
+        return array_merge(
+            [
+                'url' => $this->url,
+                'token' => $this->token,
+                'bucket' => $this->bucket,
+                'org' => $this->org,
+                'precision' => $this->precision,
+                'allow_redirects' => $this->allowRedirects,
+                'debug' => $this->debug,
+                'logFile' => $this->logFile,
+                'httpClient' => $this->httpClient,
+                'verifySSL' => $this->verifySSL,
+                'timeout' => $this->timeout,
+                'proxy' => $this->proxy,
+                'tags' => $this->tags,
+            ],
+            ($this->udp instanceof ClientOptionsUdp) ? $this->udp->toArray() : [],
+        );
+    }
+}

--- a/src/InfluxDB2/ClientOptionsUdp.php
+++ b/src/InfluxDB2/ClientOptionsUdp.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace InfluxDB2;
+
+use InfluxDB2\Model\WritePrecision;
+use Psr\Http\Client\ClientInterface;
+
+class ClientOptionsUdp
+{
+    public string $host;
+    /** @var int<1, 65535> $udpPort */
+    public int $port;
+    /** @var 4|6 $ipVersion */
+    public int $ipVersion;
+
+    public function __construct(
+        string $host,
+        int $port,
+        int $ipVersion
+    ) {
+        if (
+            filter_var($host, FILTER_VALIDATE_IP) === false &&
+            filter_var($host, FILTER_VALIDATE_DOMAIN) === false
+        ) {
+            throw new \InvalidArgumentException('UDP host must be a valid IP or domain name');
+        }
+        if ($port < 1 || $port > 65535) {
+            throw new \InvalidArgumentException('UDP port must be an integer between 1 and 65535');
+        }
+        if (!in_array($ipVersion, [4, 6], true)) {
+            throw new \InvalidArgumentException('IP version must be 4 or 6');
+        }
+        $this->host = $host;
+        $this->port = $port;
+        $this->ipVersion = $ipVersion;
+    }
+
+    /**
+     * @param array{
+     *     url: string,
+     *     udpHost?: string,
+     *     udpPort?: int<1, 65535>,
+     *     ipVersion?: 4|6,
+     * } $options
+     */
+    public static function fromArray(array $options): self
+    {
+        if (
+            !array_key_exists('udpHost', $options) &&
+            !array_key_exists('url', $options)
+        ) {
+            throw new \InvalidArgumentException('Either udpHost or url must be provided');
+        }
+        if (!array_key_exists('udpHost', $options)) {
+            $host = parse_url($options['url'], PHP_URL_HOST);
+            if ($host === false) {
+                throw new \InvalidArgumentException('url must be a valid URL');
+            }
+        } else {
+            $host = $options['udpHost'];
+        }
+        if (!array_key_exists('udpPort', $options)) {
+            throw new \InvalidArgumentException('udpPort must be provided');
+        }
+        return new self(
+            $host,
+            $options['udpPort'],
+            $options['ipVersion'] ?? 4
+        );
+    }
+
+    /**
+     * @return array{
+     *     udpHost: string,
+     *     udpPort: int<1, 65535>,
+     *     ipVersion: 4|6,
+     * }
+     */
+    public function toArray(): array
+    {
+        return [
+            'udpHost' => $this->host,
+            'udpPort' => $this->port,
+            'ipVersion' => $this->ipVersion,
+        ];
+    }
+
+    /**
+     * Returns the socket domain for the UDP connection.
+     *
+     * @return int The socket domain (AF_INET or AF_INET6).
+     * @throws \InvalidArgumentException When invalid IP version is provided
+     */
+    public function getSocketDomain(): int
+    {
+        if (!in_array($this->ipVersion, [4, 6], true)) {
+            throw new \InvalidArgumentException('IP version must be 4 or 6');
+        }
+        return $this->ipVersion === 4 ? AF_INET : AF_INET6;
+    }
+
+}

--- a/src/InfluxDB2/Configuration.php
+++ b/src/InfluxDB2/Configuration.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Configuration
  * PHP version 5

--- a/src/InfluxDB2/DefaultApi.php
+++ b/src/InfluxDB2/DefaultApi.php
@@ -20,43 +20,28 @@ use Psr\Http\Message\UriFactoryInterface;
 
 class DefaultApi
 {
-    public $options;
-    /**
-     * @var ClientInterface
-     */
-    public $http;
-
-    /**
-     * @var RequestFactoryInterface
-     */
-    private $requestFactory;
-
-    /**
-     * @var StreamFactoryInterface
-     */
-    private $streamFactory;
-
-    /**
-     * @var UriFactoryInterface
-     */
-    private $uriFactory;
+    public ClientOptions $options;
+    public ClientInterface $http;
+    private RequestFactoryInterface $requestFactory;
+    private StreamFactoryInterface $streamFactory;
+    private UriFactoryInterface $uriFactory;
 
     /**
      * DefaultApi constructor.
-     * @param array $options
+     * @param ClientOptions $options
      */
-    public function __construct(array $options)
+    public function __construct(ClientOptions $options)
     {
         $this->options = $options;
 
         $guzzleHttp = "GuzzleHttp\Client";
-        if ($this->options['httpClient'] ?? false) {
-            $client = $this->options['httpClient'];
+        if ($this->options->httpClient instanceof ClientInterface) {
+            $client = $this->options->httpClient;
         } elseif (ClassDiscovery::safeClassExists($guzzleHttp)) {
             $client = new $guzzleHttp([
-                'timeout' => $this->options['timeout'] ?? 10,
-                'verify' => $this->options['verifySSL'] ?? true,
-                'proxy' => $this->options['proxy'] ?? null
+                'timeout' => $this->options->timeout ?? 10,
+                'verify' => $this->options->verifySSL ?? true,
+                'proxy' => $this->options->proxy ?? null
             ]);
         } else {
             $client = Psr18ClientDiscovery::find();
@@ -69,17 +54,23 @@ class DefaultApi
     }
 
     /**
-     * @param $payload
-     * @param $uriPath
-     * @param $queryParams
+     * @param string $payload String content with which to populate the stream.
+     * @param string $uriPath The URI associated with the request.
+     * @param array<string, string> $queryParams The query string to use with the new instance.
      * @return ResponseInterface
      */
-    public function post($payload, $uriPath, $queryParams): ResponseInterface
+    public function post(string $payload, string $uriPath, array $queryParams): ResponseInterface
     {
         return $this->request($payload, $uriPath, $queryParams, 'POST');
     }
 
-    public function get($payload, $uriPath, $queryParams): ResponseInterface
+    /**
+     * @param string $payload String content with which to populate the stream.
+     * @param string $uriPath The URI associated with the request.
+     * @param array<string, string> $queryParams The query string to use with the new instance.
+     * @return ResponseInterface
+     */
+    public function get(string $payload, string $uriPath, array $queryParams): ResponseInterface
     {
         return $this->request($payload, $uriPath, $queryParams, 'GET');
     }
@@ -95,15 +86,15 @@ class DefaultApi
         $plugins = [
             new Plugin\HeaderDefaultsPlugin([
                 'User-Agent' => 'influxdb-client-php/' . Client::VERSION,
-                'Authorization' => "Token {$this->options['token']}",
+                'Authorization' => "Token {$this->options->token}",
             ]),
         ];
 
-        $allow_redirects = $this->options['allow_redirects'] ?? true;
-        if ($allow_redirects) {
+        $allow_redirects = $this->options->allowRedirects ?? true;
+        if ($allow_redirects !== false) {
             $plugins[] = new Plugin\RedirectPlugin(is_array($allow_redirects) ? $allow_redirects : []);
         }
-        if ($this->options['debug'] ?? false) {
+        if ($this->options->debug ?? false) {
             $plugins[] = new DebugHttpPlugin($this->options);
         }
         return new PluginClient($client, $plugins);
@@ -127,7 +118,7 @@ class DefaultApi
         array  $queryParams
     ): RequestInterface {
         $uri = $this->uriFactory
-            ->createUri($this->options['url'])
+            ->createUri($this->options->url)
             ->withPath($uriPath)
             ->withQuery(http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986));
         $request = $this->requestFactory->createRequest($method, $uri);
@@ -178,8 +169,8 @@ class DefaultApi
             throw new ApiException(
                 "[{$e->getCode()}] {$e->getMessage()}",
                 $e->getCode(),
-                $e->getResponse() ? $e->getResponse()->getHeaders() : null,
-                $e->getResponse() ? $e->getResponse()->getBody()->getContents() : null,
+                $e->getResponse() instanceof ResponseInterface ? $e->getResponse()->getHeaders() : null,
+                $e->getResponse() instanceof ResponseInterface ? $e->getResponse()->getBody()->getContents() : null,
                 $e
             );
         } catch (ClientExceptionInterface $e) {
@@ -193,9 +184,10 @@ class DefaultApi
         }
     }
 
-    protected function check($key, $value)
+    protected function check(string $key, $value): void
     {
-        if ((!isset($value) || trim($value) === '')) {
+        $optionsArray = $this->options->toArray();
+        if (!isset($value) || trim($value) === '') {
             $options = implode(', ', array_map(
                 function ($v, $k) {
                     if (is_array($v)) {
@@ -204,14 +196,21 @@ class DefaultApi
                         return $k . '=' . $v;
                     }
                 },
-                $this->options,
-                array_keys($this->options)
+                $optionsArray,
+                array_keys($optionsArray)
             ));
             throw new InvalidArgumentException("The '{$key}' should be defined as argument or default option: {$options}");
         }
     }
 
-    private function request($payload, $uriPath, $queryParams, $method): ResponseInterface
+    /**
+     * @param string $payload String content with which to populate the stream.
+     * @param string $uriPath The URI associated with the request.
+     * @param array<string, string> $queryParams The query string to use with the new instance.
+     * @param string $method The HTTP method associated with the request.
+     * @return ResponseInterface
+     */
+    private function request(string $payload, string $uriPath, array $queryParams, string $method): ResponseInterface
     {
         $headers = [
             'Content-Type' => 'application/json'
@@ -226,12 +225,13 @@ class DefaultApi
      *
      * @param string $level LOG level
      * @param string $message Message to log
-     * @param array $options Client options with logFile.
+     * @param ClientOptions|null $options Client options with logFile.
      * @return void
      */
-    public static function log(string $level, string $message, array $options): void
+    public static function log(string $level, string $message, ?ClientOptions $options): void
     {
         $logDate = date('H:i:s d-M-Y');
-        file_put_contents($options["logFile"] ?? "php://output", "[$logDate]: [$level] - $message" . PHP_EOL, FILE_APPEND);
+        $logFileName = ($options instanceof ClientOptions) ? $options->logFile : null;
+        file_put_contents($logFileName ?? "php://output", "[$logDate]: [$level] - $message" . PHP_EOL, FILE_APPEND);
     }
 }

--- a/src/InfluxDB2/FluxColumn.php
+++ b/src/InfluxDB2/FluxColumn.php
@@ -8,22 +8,27 @@ namespace InfluxDB2;
  */
 class FluxColumn
 {
-    public $index;
-    public $label;
-    public $dataType;
-    public $group;
-    public $defaultValue;
+    public ?int $index;
+    public ?string $label;
+    public ?string $dataType;
+    public ?bool $group;
+    public ?string $defaultValue;
 
     /**
      * FluxColumn constructor.
-     * @param $index int column number
-     * @param $label string column label
-     * @param $dataType string data type
-     * @param $group bool is group column
-     * @param $defaultValue string default empty value
+     * @param ?int $index column number
+     * @param ?string $label column label
+     * @param ?string $dataType data type
+     * @param ?bool $group is group column
+     * @param ?string $defaultValue default empty value
      */
-    public function __construct($index = null, $label = null, $dataType = null, $group = null, $defaultValue = null)
-    {
+    public function __construct(
+        ?int $index = null,
+        ?string $label = null,
+        ?string $dataType = null,
+        ?bool $group = null,
+        ?string $defaultValue = null
+    ) {
         $this->index = $index;
         $this->label = $label;
         $this->dataType = $dataType;

--- a/src/InfluxDB2/FluxCsvParser.php
+++ b/src/InfluxDB2/FluxCsvParser.php
@@ -2,6 +2,8 @@
 
 namespace InfluxDB2;
 
+use Psr\Http\Message\StreamInterface;
+
 /**
  * Class FluxCsvParser us used to construct FluxResult from CSV.
  * @package InfluxDB2
@@ -13,36 +15,33 @@ class FluxCsvParser
     private const ANNOTATION_DEFAULT = '#default';
     private const ANNOTATIONS = [self::ANNOTATION_DATATYPE, self::ANNOTATION_GROUP, self::ANNOTATION_DEFAULT];
 
-    /* @var  $variable FluxTable[] */
-    public $tables;
+    /* @var array<int, FluxTable> $variable */
+    public array $tables;
 
-    private $response;
-    private $stream;
-    private $responseMode;
+    private ?StreamInterface $response;
+    private bool $stream;
+    private string $responseMode;
+    /** @var resource|false $resource */
     private $resource;
 
-    /* @var  $variable int */
-    private $tableIndex = 0;
-    private $tableId;
-
-    private $startNewTable;
+    private int $tableIndex = 0;
+    private int $tableId = -1;
+    private bool $startNewTable = false;
 
     /** @var FluxTable */
     private $table;
-    private $groups = [];
+    /** @var array<int, bool|'true'|'false'> */
+    private array $groups = [];
 
-    private $parsingStateError;
+    private bool $parsingStateError = false;
 
-    public $closed;
-
-    /** @var FluxColumn[] */
-    private $fluxColumns;
+    public bool $closed;
 
     /**
      * FluxCsvParser constructor.
-     * @param $response mixed response to by parsed
-     * @param $stream bool use streaming
-     * @param $responseMode string metadata expected in response ('full', 'only_names')
+     * @param StreamInterface|string $response mixed response to by parsed
+     * @param bool $stream use streaming
+     * @param string $responseMode string metadata expected in response ('full', 'only_names')
      */
     public function __construct($response, bool $stream = false, string $responseMode = "full")
     {
@@ -58,31 +57,41 @@ class FluxCsvParser
         $this->closed = false;
     }
 
+    /**
+     * @param string $string
+     * @return false|resource
+     */
     private function stringToStream(string $string)
     {
         $stream = fopen('php://memory', 'r+');
+        if ($stream === false) {
+            return false;
+        }
         fwrite($stream, $string);
         rewind($stream);
         return $stream;
     }
 
-    public function parse()
+    public function parse(): self
     {
         iterator_to_array($this->each());
 
         return $this;
     }
 
-    public function each()
+    /**
+     * @return \Generator<?FluxRecord>
+     */
+    public function each(): \Generator
     {
         try {
             while (($csv = fgetcsv($this->resource, null, ',', '"', '\\')) !== false) {
-                if (!isset($csv) || (count($csv) == 1 && $csv[0] == null)) {
+                if (!isset($csv) || (count($csv) === 1 && $csv[0] == null)) {
                     continue;
                 }
 
                 //skip empty csv row
-                if ($csv[1] == 'error' && $csv[2] == 'reference') {
+                if ($csv[1] === 'error' && $csv[2] === 'reference') {
                     $this->parsingStateError = true;
                     continue;
                 }
@@ -93,7 +102,7 @@ class FluxCsvParser
                     $referenceValue = $csv[2];
                     throw new FluxQueryError(
                         $error,
-                        !isset($referenceValue) || trim($referenceValue) === '' ? 0 : $referenceValue
+                        !isset($referenceValue) || trim($referenceValue) === '' ? 0 : (int) $referenceValue
                     );
                 }
 
@@ -108,12 +117,12 @@ class FluxCsvParser
         }
     }
 
-    private function parseLine(array $csv)
+    private function parseLine(array $csv): ?FluxRecord
     {
         $token = $csv[0];
         # start new table
-        if ((in_array($token, self::ANNOTATIONS) && !$this->startNewTable)
-            || ($this->responseMode == "only_names" && is_null($this->table))) {
+        if ((in_array($token, self::ANNOTATIONS, true) && !$this->startNewTable)
+            || ($this->responseMode === "only_names" && is_null($this->table))) {
             # Return already parsed DataFrame
             $this->startNewTable = true;
             $this->table = new FluxTable();
@@ -125,15 +134,15 @@ class FluxCsvParser
 
             $this->tableIndex += 1;
             $this->tableId = -1;
-        } elseif ($this->table == null) {
+        } elseif ($this->table === null) {
             throw new FluxCsvParserException('Unable to parse CSV response. FluxTable definition was not found.');
         }
 
-        if (self::ANNOTATION_DATATYPE == $token) {
+        if (self::ANNOTATION_DATATYPE === $token) {
             $this->addDataTypes($this->table, $csv);
-        } elseif (self::ANNOTATION_GROUP == $token) {
+        } elseif (self::ANNOTATION_GROUP === $token) {
             $this->groups = $csv;
-        } elseif (self::ANNOTATION_DEFAULT == $token) {
+        } elseif (self::ANNOTATION_DEFAULT === $token) {
             $this->addDefaultEmptyValues($this->table, $csv);
         } else {
             return $this->parseValues($csv);
@@ -141,7 +150,13 @@ class FluxCsvParser
         return null;
     }
 
-    private function parseRecord(int $tableIndex, FluxTable $table, array $csv)
+    /**
+     * @param int $tableIndex
+     * @param FluxTable $table
+     * @param array<int, mixed> $csv
+     * @return FluxRecord
+     */
+    private function parseRecord(int $tableIndex, FluxTable $table, array $csv): FluxRecord
     {
         $record = new FluxRecord($tableIndex);
         foreach ($table->columns as $fluxColumn) {
@@ -154,35 +169,51 @@ class FluxCsvParser
         return $record;
     }
 
-    private function addDataTypes(FluxTable $table, array $data_types)
+    /**
+     * @param FluxTable $table
+     * @param array<int, string|null> $data_types
+     */
+    private function addDataTypes(FluxTable $table, array $data_types): void
     {
         for ($i = 1; $i < sizeof($data_types); ++$i) {
             $columnDef = new FluxColumn();
             $columnDef->index = $i - 1;
             $columnDef->dataType = $data_types[$i];
-            array_push($table->columns, $columnDef);
+            $table->columns[] = $columnDef;
         }
     }
 
-    private function addGroups(FluxTable $table, $csv)
+    /**
+     * @param FluxTable $table
+     * @param array<int, 'true'|'false'|bool> $csv
+     */
+    private function addGroups(FluxTable $table, array $csv): void
     {
         $i = 1;
-        foreach ($table->columns as &$column) {
-            $column->group = $csv[$i] == 'true';
+        foreach ($table->columns as $column) {
+            $column->group = $csv[$i] === 'true' || $csv[$i] === true;
             $i++;
         }
     }
 
-    private function addDefaultEmptyValues(FluxTable $table, $defaultValues)
+    /**
+     * @param FluxTable $table
+     * @param array<int, mixed> $defaultValues
+     */
+    private function addDefaultEmptyValues(FluxTable $table, array $defaultValues): void
     {
         $i = 1;
-        foreach ($table->columns as &$column) {
+        foreach ($table->columns as $column) {
             $column->defaultValue = $defaultValues[$i];
             $i++;
         }
     }
 
-    private function addColumnNamesAndTags(FluxTable $table, array $csv)
+    /**
+     * @param FluxTable $table
+     * @param array<int, string> $csv
+     */
+    private function addColumnNamesAndTags(FluxTable $table, array $csv): void
     {
         $i = 1;
 
@@ -191,14 +222,14 @@ class FluxCsvParser
             $i++;
         }
 
-        $duplicates = array();
+        $duplicates = [];
         foreach (array_count_values($csv) as $label => $count) {
             if ($count > 1) {
                 $duplicates[] = $label;
             }
         }
 
-        if (count($duplicates) > 0) {
+        if ($duplicates !== []) {
             $duplicatesStr = implode(", ", $duplicates);
             print "The response contains columns with duplicated names: {$duplicatesStr}\n";
             print "You should use the 'FluxRecord.row' to access your data instead of 'FluxRecord.values'.";
@@ -206,11 +237,11 @@ class FluxCsvParser
     }
 
 
-    private function parseValues(array $csv)
+    private function parseValues(array $csv): ?FluxRecord
     {
         # parse column names
         if ($this->startNewTable) {
-            if ($this->responseMode == 'only_names' && empty($this->table->columns)) {
+            if ($this->responseMode === 'only_names' && empty($this->table->columns)) {
                 $this->addDataTypes($this->table, array_fill(0, sizeof($csv), 'string'));
                 $this->groups = array_fill(0, sizeof($csv), 'false');
             }
@@ -221,17 +252,17 @@ class FluxCsvParser
         }
 
         $currentId = (int)$csv[2];
-        if ($this->tableId == -1) {
+        if ($this->tableId === -1) {
             $this->tableId = $currentId;
         }
 
-        if ($this->tableId != $currentId) {
+        if ($this->tableId !== $currentId) {
             # create new table with previous column headers settings
-            $this->fluxColumns = $this->table->columns;
+            $fluxColumns = $this->table->columns;
             $this->table = new FluxTable();
 
-            foreach ($this->fluxColumns as &$column) {
-                array_push($this->table->columns, $column);
+            foreach ($fluxColumns as $column) {
+                $this->table->columns[] = $column;
             }
 
             if (!$this->stream) {
@@ -248,7 +279,7 @@ class FluxCsvParser
             return $fluxRecord;
         } else {
             $fluxTable = $this->tables[$this->tableIndex - 1];
-            array_push($fluxTable->records, $fluxRecord);
+            $fluxTable->records[] = $fluxRecord;
         }
 
         return null;
@@ -256,7 +287,7 @@ class FluxCsvParser
 
     private function toValue($strVal, FluxColumn $column)
     {
-        if ($strVal == null || $strVal == '') {
+        if ($strVal === null || $strVal === '') {
             $defaultValue = $column->defaultValue;
             if (empty($defaultValue)) {
                 return null;
@@ -264,33 +295,33 @@ class FluxCsvParser
             return $this->toValue($defaultValue, $column);
         }
 
-        if ('string' == $column->dataType) {
+        if ('string' === $column->dataType) {
             return $strVal;
         }
 
-        if ('boolean' == $column->dataType) {
-            return "true" == $strVal;
+        if ('boolean' === $column->dataType) {
+            return "true" === $strVal;
         }
 
-        if ('unsignedLong' == $column->dataType || 'long' == $column->dataType) {
+        if ('unsignedLong' === $column->dataType || 'long' === $column->dataType) {
             return intval($strVal);
         }
 
-        if ('double' == $column->dataType) {
-            if ($strVal == '+Inf') {
+        if ('double' === $column->dataType) {
+            if ($strVal === '+Inf') {
                 return INF;
             }
-            if ($strVal == '-Inf') {
+            if ($strVal === '-Inf') {
                 return -INF;
             }
             return (float)$strVal;
         }
 
-        if ('base64Binary' == $column->dataType) {
-            return base64_decode($strVal);
+        if ('base64Binary' === $column->dataType) {
+            return base64_decode($strVal, true);
         }
 
-        if ('dateTime:RFC3339' == $column->dataType || 'dateTime:RFC3339Nano' == $column->dataType) {
+        if ('dateTime:RFC3339' === $column->dataType || 'dateTime:RFC3339Nano' === $column->dataType) {
             ##todo nanoseconds precission, php datetime is only in microseconds precision
             return $strVal;
         }
@@ -298,7 +329,7 @@ class FluxCsvParser
         return $strVal;
     }
 
-    private function closeConnection()
+    private function closeConnection(): void
     {
         # Close CSV Parser
         $this->closed = true;

--- a/src/InfluxDB2/FluxCsvParserException.php
+++ b/src/InfluxDB2/FluxCsvParserException.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace InfluxDB2;
 
 class FluxCsvParserException extends \RuntimeException

--- a/src/InfluxDB2/FluxRecord.php
+++ b/src/InfluxDB2/FluxRecord.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace InfluxDB2;
 
 use ArrayAccess;
@@ -13,16 +12,19 @@ use RuntimeException;
  */
 class FluxRecord implements ArrayAccess
 {
-    public $table;
-    public $values;
-    public $row;
+    public int $table;
+    /** @var array<array-key, mixed>|null  */
+    public ?array $values;
+    /** @var array<array-key, mixed>|null  */
+    public ?array $row;
 
     /**
      * FluxRecord constructor.
-     * @param $table int table index
-     * @param $values array array with record values, key is the column name
+     * @param int $table table index
+     * @param array<array-key, mixed>|null $values array with record values, key is the column name
+     * @param array<array-key, mixed>|null $row array with record values, index is the column index
      */
-    public function __construct($table, $values = null, $row = null)
+    public function __construct(int $table, ?array $values = null, ?array $row = null)
     {
         $this->table = $table;
         $this->values = $values;

--- a/src/InfluxDB2/FluxTable.php
+++ b/src/InfluxDB2/FluxTable.php
@@ -1,4 +1,5 @@
 <?php
+
 # The MIT License
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -18,6 +19,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
+
 namespace InfluxDB2;
 
 /**
@@ -27,9 +29,9 @@ namespace InfluxDB2;
 class FluxTable
 {
     /** @var FluxColumn[] */
-    public $columns;
+    public array $columns;
     /** @var FluxRecord[] */
-    public $records;
+    public array $records;
 
     /**
      * FluxTable constructor.
@@ -40,9 +42,12 @@ class FluxTable
         $this->columns = [];
     }
 
-    public function getGroupKey()
+    /**
+     * @return FluxColumn[]
+     */
+    public function getGroupKey(): array
     {
-        return array_values(array_filter($this->columns, function ($column) {
+        return array_values(array_filter($this->columns, static function (FluxColumn $column): bool {
             return $column->group;
         }));
     }

--- a/src/InfluxDB2/HealthApi.php
+++ b/src/InfluxDB2/HealthApi.php
@@ -9,9 +9,9 @@ class HealthApi extends DefaultApi
 {
     /**
      * HealthApi constructor.
-     * @param array $options
+     * @param ClientOptions $options
      */
-    public function __construct(array $options)
+    public function __construct(ClientOptions $options)
     {
         parent::__construct($options);
     }

--- a/src/InfluxDB2/Internal/DebugHttpPlugin.php
+++ b/src/InfluxDB2/Internal/DebugHttpPlugin.php
@@ -4,6 +4,7 @@ namespace InfluxDB2\Internal;
 
 use Http\Client\Common\Plugin;
 use Http\Promise\Promise;
+use InfluxDB2\ClientOptions;
 use InfluxDB2\DefaultApi;
 use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\RequestInterface;
@@ -11,9 +12,9 @@ use Psr\Http\Message\ResponseInterface;
 
 class DebugHttpPlugin implements Plugin
 {
-    private $options;
+    private ClientOptions $options;
 
-    public function __construct(array $options)
+    public function __construct(ClientOptions $options)
     {
         $this->options = $options;
     }
@@ -51,7 +52,7 @@ class DebugHttpPlugin implements Plugin
     {
         foreach ($message->getHeaders() as $key => $values) {
             $value = implode(', ', $values);
-            if (strcasecmp($key, 'Authorization') == 0) {
+            if (strcasecmp($key, 'Authorization') === 0) {
                 $value = '***';
             }
             DefaultApi::log("DEBUG", $prefix . " $key: " . $value, $this->options);

--- a/src/InfluxDB2/InvokableScriptsApi.php
+++ b/src/InfluxDB2/InvokableScriptsApi.php
@@ -19,15 +19,15 @@ use Psr\Http\Message\StreamInterface;
  */
 class InvokableScriptsApi extends DefaultApi
 {
-    private $service;
+    private InvokableScriptsService $service;
 
     /**
      * InvokableScriptsApi constructor.
      *
-     * @param array $options default array options
+     * @param ClientOptions $options default array options
      * @param InvokableScriptsService $service HTTP API for Invokable Scripts
      */
-    public function __construct(array $options, InvokableScriptsService $service)
+    public function __construct(ClientOptions $options, InvokableScriptsService $service)
     {
         parent::__construct($options);
         $this->service = $service;

--- a/src/InfluxDB2/Point.php
+++ b/src/InfluxDB2/Point.php
@@ -9,16 +9,15 @@ class Point
 {
     public const DEFAULT_WRITE_PRECISION = WritePrecision::NS;
 
-    /** @var string */
-    private $name;
+    private string $name;
     /** @var array<string, string|\Stringable|null>|null */
-    private $tags;
+    private ?array $tags;
     /** @var array<string, float|int|string|bool|null>|null */
-    private $fields;
+    private ?array $fields;
     /** @var int|float|DateTimeInterface|null */
     private $time;
     /** @var WritePrecision::S|WritePrecision::MS|WritePrecision::US|WritePrecision::NS|null */
-    private $precision;
+    private ?string $precision;
 
     /** Create DataPoint instance for specified measurement name.
      *

--- a/src/InfluxDB2/PointSettings.php
+++ b/src/InfluxDB2/PointSettings.php
@@ -1,18 +1,21 @@
 <?php
 
-
 namespace InfluxDB2;
 
 class PointSettings
 {
-    private $defaultTags;
+    /** @var array<string, string> */
+    private array $defaultTags;
 
+    /**
+     * @param array<string, string>|null $defaultTags
+     */
     public function __construct(?array $defaultTags = null)
     {
         $this->defaultTags = is_null($defaultTags) ? [] : $defaultTags;
     }
 
-    public function addDefaultTag(string $key, string $expression)
+    public function addDefaultTag(string $key, string $expression): void
     {
         $this->defaultTags[$key] = $expression;
     }
@@ -26,7 +29,10 @@ class PointSettings
         return $value;
     }
 
-    public function getDefaultTags()
+    /**
+     * @return array<string, string>
+     */
+    public function getDefaultTags(): array
     {
         return $this->defaultTags;
     }

--- a/src/InfluxDB2/QueryApi.php
+++ b/src/InfluxDB2/QueryApi.php
@@ -13,13 +13,13 @@ use Psr\Http\Message\ResponseInterface;
  */
 class QueryApi extends DefaultApi
 {
-    private $DEFAULT_DIALECT;
+    private Dialect $DEFAULT_DIALECT;
 
     /**
      * QueryApi constructor.
-     * @param array $options
+     * @param ClientOptions $options
      */
-    public function __construct(array $options)
+    public function __construct(ClientOptions $options)
     {
         parent::__construct($options);
         $this->DEFAULT_DIALECT = new Dialect([
@@ -40,9 +40,9 @@ class QueryApi extends DefaultApi
      */
     public function queryRaw($query, ?string $org = null, ?Dialect $dialect = null): ?string
     {
-        $result = $this->postQuery($query, $org, $dialect ?: $this->DEFAULT_DIALECT);
+        $result = $this->postQuery($query, $org, $dialect ?? $this->DEFAULT_DIALECT);
 
-        if ($result == null) {
+        if ($result === null) {
             return null;
         }
 
@@ -64,9 +64,9 @@ class QueryApi extends DefaultApi
             $query->setDialect($this->DEFAULT_DIALECT);
         }
 
-        $response = $this->postQuery($query, $org, $dialect ?: $this->DEFAULT_DIALECT);
+        $response = $this->postQuery($query, $org, $dialect ?? $this->DEFAULT_DIALECT);
 
-        if ($response == null) {
+        if ($response === null) {
             return null;
         }
 
@@ -79,7 +79,7 @@ class QueryApi extends DefaultApi
     /**
      * Executes the Flux query against the InfluxDB 2.x and returns generator to stream the result.
      *
-     * @param string| Query $query
+     * @param string|Query $query
      * @param string|null $org
      * @param Dialect|null $dialect
      *
@@ -91,33 +91,44 @@ class QueryApi extends DefaultApi
             $query->setDialect($this->DEFAULT_DIALECT);
         }
 
-        $response = $this->postQuery($query, $org, $dialect ?: $this->DEFAULT_DIALECT);
+        $response = $this->postQuery($query, $org, $dialect ?? $this->DEFAULT_DIALECT);
 
-        if ($response == null) {
+        if ($response === null) {
             return null;
         }
 
         return new FluxCsvParser($response->getBody(), true);
     }
 
-    private function postQuery($query, $org, $dialect): ?ResponseInterface
+    /**
+     * @param string|Query $query
+     * @param string|null $org
+     * @param Dialect|null $dialect
+     * @return ResponseInterface|null
+     */
+    private function postQuery($query, ?string $org = null, ?Dialect $dialect = null): ?ResponseInterface
     {
-        $orgParam = $org ?: $this->options["org"];
+        $orgParam = $org ?? $this->options->org;
         $this->check("org", $orgParam);
 
         $payload = $this->generatePayload($query, $dialect);
         $queryParams = ["org" => $orgParam];
 
-        if ($payload == null) {
+        if ($payload === null) {
             return null;
         }
 
         return $this->post($payload->__toString(), "/api/v2/query", $queryParams);
     }
 
-    private function generatePayload($query, $dialect): ?Query
+    /**
+     * @param string|Query $query
+     * @param Dialect|null $dialect
+     * @return Query|null
+     */
+    private function generatePayload($query, ?Dialect $dialect = null): ?Query
     {
-        if ((!isset($query) || trim($query) === '')) {
+        if (!isset($query) || trim($query) === '') {
             return null;
         }
 

--- a/src/InfluxDB2/UdpWriter.php
+++ b/src/InfluxDB2/UdpWriter.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace InfluxDB2;
 
 /**
@@ -26,33 +25,27 @@ namespace InfluxDB2;
  */
 class UdpWriter implements Writer
 {
-    public $options = [];
+    public ClientOptionsUdp $options;
 
     /**
-     * @var resource
+     * @var resource|null
      */
-    protected $socket;
+    protected $socket = null;
 
     /**
      * UdpWriter constructor.
-     * @param array $options
+     * @param ClientOptions $options
      * @throws \Exception
      */
-    public function __construct($options)
+    public function __construct(ClientOptions $options)
     {
-        $this->options = $options;
-        if (empty($this->options['udpPort'])) {
-            throw new \Exception('udpPort option does not specified');
-        }
-        if (empty($this->options['udpHost'])) {
-            $this->options['udpHost'] = parse_url($this->options['url'], PHP_URL_HOST);
-        }
+        $this->options = $options->udp;
     }
 
     /**
      * @inheritDoc
      */
-    public function write($data)
+    public function write($data): void
     {
         $payload = WritePayloadSerializer::generatePayload($data);
         if (empty($payload)) {
@@ -72,55 +65,41 @@ class UdpWriter implements Writer
      * @return false|int
      * @throws \Exception
      */
-    protected function writeSocket($payload)
+    protected function writeSocket(string $payload)
     {
         $bytesSent = false;
-        if ($socket = $this->getSocket()) {
-            $bytesSent = socket_sendto($socket, $payload, strlen($payload), 0, $this->options['udpHost'], $this->options['udpPort']);
+        if (is_resource($socket = $this->getSocket())) {
+            $bytesSent = socket_sendto($socket, $payload, strlen($payload), 0, $this->options->host, $this->options->port);
         }
         return $bytesSent;
     }
 
     /**
      * Create (if not exists) socket to write UDP datagrams
-     * @return false|resource
+     * @return resource
      * @throws \Exception
      */
     protected function getSocket()
     {
-        if (empty($this->socket)) {
-            $this->socket = socket_create($this->getConfiguredInetVersion(), SOCK_DGRAM, SOL_UDP);
+        if (!is_resource($this->socket)) {
+            $this->socket = socket_create($this->options->getSocketDomain(), SOCK_DGRAM, SOL_UDP);
+
+            if (!is_resource($this->socket)) {
+                throw new \Exception('Unable to create socket');
+            }
         }
         return $this->socket;
     }
 
     /**
-     * @throws \Exception
-     * @return int socket domain constant
-     */
-    private function getConfiguredInetVersion()
-    {
-        $configuredIpVersion = $this->options['ipVersion'] ?? 4;
-
-        switch ($configuredIpVersion) {
-            case 4:
-                return AF_INET;
-            case 6:
-                return AF_INET6;
-            default:
-                throw new \Exception('ipVersion option invalid!');
-        }
-    }
-
-    /**
      * Closes connection
      */
-    public function close()
+    public function close(): void
     {
-        if (isset($this->socket)) {
+        if (is_resource($this->socket)) {
             socket_close($this->socket);
-
-            $this->socket = null;
         }
+
+        $this->socket = null;
     }
 }

--- a/src/InfluxDB2/Worker.php
+++ b/src/InfluxDB2/Worker.php
@@ -7,13 +7,12 @@ use SplQueue;
 
 class Worker
 {
-    /** @var WriteApi */
-    private $client;
+    private WriteApi $client;
+    /** @var SplQueue<BatchItem> */
+    private SplQueue $queue;
+    private WriteOptions $writeOptions;
 
-    private $queue;
-    private $writeOptions;
-
-    public function __construct($client)
+    public function __construct(WriteApi $client)
     {
         $this->client = $client;
         $this->writeOptions = $client->writeOptions;
@@ -21,7 +20,7 @@ class Worker
         $this->queue = new SplQueue();
     }
 
-    public function push($payload)
+    public function push(BatchItem $payload): void
     {
         $this->queue->enqueue($payload);
 
@@ -30,14 +29,14 @@ class Worker
         }
     }
 
-    public function flush()
+    public function flush(): void
     {
-        while ($this->queue->count() != 0) {
+        while ($this->queue->count() !== 0) {
             $this->checkBackgroundQueue(false);
         }
     }
 
-    private function checkBackgroundQueue(bool $size)
+    private function checkBackgroundQueue(bool $size): void
     {
         $data = array();
         $points = 0;
@@ -46,7 +45,7 @@ class Worker
             return;
         }
 
-        while (($points < $this->writeOptions->batchSize) && $this->queue->count() != 0) {
+        while (($points < $this->writeOptions->batchSize) && $this->queue->count() !== 0) {
             try {
                 $item = $this->queue->dequeue();
 
@@ -55,7 +54,7 @@ class Worker
 
                 if ($index === null) {
                     $data[] = array('key' => $key, 'data' => array());
-                    $index = array_keys($data)[count($data)-1];
+                    $index = array_keys($data)[count($data) - 1];
                 }
 
                 $data[$index]['data'][] = $item->data;
@@ -70,21 +69,32 @@ class Worker
         }
     }
 
-    private function existsKey($key, $data): ?int
+    /**
+     * @param BatchItemKey $key
+     * @param array<int, array{key: BatchItemKey, data: list<string>}> $data
+     * @return int|null
+     */
+    private function existsKey(BatchItemKey $key, array $data): ?int
     {
         foreach ($data as $item) {
             $itemKey = $item['key'];
             if ($key->precision === $itemKey->precision &&
                 $key->bucket === $itemKey->bucket &&
                 $key->org === $itemKey->org) {
-                return array_search($item, $data);
+                $found = array_search($item, $data, true);
+                if ($found !== false) {
+                    return $found;
+                }
             }
         }
 
         return null;
     }
 
-    private function write($data)
+    /**
+     * @param array<int, array{key: BatchItemKey, data: list<string>}> $data
+     */
+    private function write(array $data): void
     {
         foreach ($data as $item) {
             $key = $item['key'];

--- a/src/InfluxDB2/WriteApi.php
+++ b/src/InfluxDB2/WriteApi.php
@@ -10,28 +10,35 @@ use InfluxDB2\Model\WritePrecision;
  */
 class WriteApi extends DefaultApi implements Writer
 {
-    public $writeOptions;
-    public $pointSettings;
-
-    /** @var Worker */
-    private $worker;
-    public $closed = false;
+    public WriteOptions $writeOptions;
+    public PointSettings $pointSettings;
+    private Worker $worker;
+    public bool $closed = false;
 
     /**
      * WriteApi constructor.
-     * @param $options
-     * @param array|null $writeOptions
-     * @param array|null $pointSettings
+     * @param ClientOptions $options
+     * @param array{
+     *      writeType?: WriteType::SYNCHRONOUS|WriteType::BATCHING,
+     *      batchSize?: int,
+     *      retryInterval?: int,
+     *      maxRetries?: int,
+     *      maxRetryDelay?: int,
+     *      maxRetryTime?: int,
+     *      exponentialBase?: int,
+     *      jitterInterval?: int,
+     *  }|null $writeOptions
+     * @param array<string, string>|null $pointSettings
      */
-    public function __construct($options, ?array $writeOptions = null, ?array $pointSettings = null)
+    public function __construct(ClientOptions $options, ?array $writeOptions = null, ?array $pointSettings = null)
     {
         parent::__construct($options);
-        $this->writeOptions = new WriteOptions($writeOptions) ?: new WriteOptions();
-        $this->pointSettings = new PointSettings($pointSettings) ?: new PointSettings();
+        $this->writeOptions = new WriteOptions($writeOptions ?? []);
+        $this->pointSettings = new PointSettings($pointSettings ?? []);
 
-        if (array_key_exists('tags', $options)) {
-            foreach (array_keys($options['tags']) as $key) {
-                $this->pointSettings->addDefaultTag($key, $options['tags'][$key]);
+        if ($options->tags !== null) {
+            foreach (array_keys($options->tags) as $key) {
+                $this->pointSettings->addDefaultTag($key, $options->tags[$key]);
             }
         }
     }
@@ -64,7 +71,7 @@ class WriteApi extends DefaultApi implements Writer
      * @param string|null $org specifies the destination organization for writes
      * @throws ApiException
      */
-    public function write($data, ?string $precision = null, ?string $bucket = null, ?string $org = null)
+    public function write($data, ?string $precision = null, ?string $bucket = null, ?string $org = null): void
     {
         $precisionParam = $this->getOption("precision", $precision);
         $bucketParam = $this->getOption("bucket", $bucket);
@@ -78,18 +85,22 @@ class WriteApi extends DefaultApi implements Writer
 
         $payload = WritePayloadSerializer::generatePayload($data, $precisionParam, $bucketParam, $orgParam, $this->writeOptions->writeType);
 
-        if ($payload == null) {
+        if ($payload === null) {
             return;
         }
 
-        if (WriteType::BATCHING == $this->writeOptions->writeType) {
+        if ($payload instanceof BatchItem) {
             $this->worker()->push($payload);
         } else {
             $this->writeRaw($payload, $precisionParam, $bucketParam, $orgParam);
         }
     }
 
-    private function addDefaultTags(&$data)
+    /**
+     * @param array|Point $data
+     * @return void
+     */
+    private function addDefaultTags(&$data): void
     {
         $defaultTags = $this->pointSettings->getDefaultTags();
 
@@ -121,7 +132,7 @@ class WriteApi extends DefaultApi implements Writer
      *
      * @see \InfluxDB2\Model\WritePrecision
      */
-    public function writeRaw(string $data, ?string $precision = null, ?string $bucket = null, ?string $org = null)
+    public function writeRaw(string $data, ?string $precision = null, ?string $bucket = null, ?string $org = null): void
     {
         $precisionParam = $this->getOption("precision", $precision);
         $bucketParam = $this->getOption("bucket", $bucket);
@@ -147,7 +158,7 @@ class WriteApi extends DefaultApi implements Writer
             $this->post($data, "/api/v2/write", $queryParams);
         });
     }
-    public function close()
+    public function close(): void
     {
         $this->closed = true;
 
@@ -167,8 +178,26 @@ class WriteApi extends DefaultApi implements Writer
         return $this->worker;
     }
 
-    private function getOption(string $optionName, ?string $precision = null): string
+    /**
+     * @param 'bucket'|'precision'|'org' $optionName
+     * @param string|null $optionalValue
+     * @return string
+     */
+    private function getOption(string $optionName, ?string $optionalValue = null): string
     {
-        return $precision ?? $this->options["$optionName"];
+        switch ($optionName) {
+            case 'precision':
+                $default = $this->options->precision;
+                break;
+            case 'bucket':
+                $default = $this->options->bucket;
+                break;
+            case 'org':
+                $default = $this->options->org;
+                break;
+            default:
+                throw new \InvalidArgumentException("Invalid option name: $optionName");
+        }
+        return $optionalValue ?? $default;
     }
 }

--- a/src/InfluxDB2/WriteOptions.php
+++ b/src/InfluxDB2/WriteOptions.php
@@ -4,22 +4,23 @@ namespace InfluxDB2;
 
 class WriteOptions
 {
-    const DEFAULT_BATCH_SIZE = 10;
-    const DEFAULT_RETRY_INTERVAL = 5000;
-    const DEFAULT_MAX_RETRIES = 5;
-    const DEFAULT_MAX_RETRY_DELAY = 125000;
-    const DEFAULT_MAX_RETRY_TIME = 180000;
-    const DEFAULT_EXPONENTIAL_BASE = 2;
-    const DEFAULT_JITTER_INTERVAL = 0;
+    public const DEFAULT_BATCH_SIZE = 10;
+    public const DEFAULT_RETRY_INTERVAL = 5000;
+    public const DEFAULT_MAX_RETRIES = 5;
+    public const DEFAULT_MAX_RETRY_DELAY = 125000;
+    public const DEFAULT_MAX_RETRY_TIME = 180000;
+    public const DEFAULT_EXPONENTIAL_BASE = 2;
+    public const DEFAULT_JITTER_INTERVAL = 0;
 
-    public $writeType;
-    public $batchSize;
-    public $retryInterval;
-    public $maxRetries;
-    public $maxRetryDelay;
-    public $exponentialBase;
-    public $jitterInterval;
-    public $maxRetryTime;
+    /** @var WriteType::SYNCHRONOUS|WriteType::BATCHING $writeType */
+    public int $writeType;
+    public int $batchSize;
+    public int $retryInterval;
+    public int $maxRetries;
+    public int $maxRetryDelay;
+    public int $exponentialBase;
+    public int $jitterInterval;
+    public int $maxRetryTime;
 
     /**
      * WriteOptions constructor.
@@ -40,7 +41,16 @@ class WriteOptions
      *              ``[5000-10000, 10000-20000, 20000-40000, 40000-80000, 80000-125000]``
      *          'jitterInterval' => the number of milliseconds before the data is written increased by a random amount
      *      ]
-     * @param array|null $writeOptions Array containing the write parameters (See above)
+     * @param array{
+     *     writeType?: WriteType::SYNCHRONOUS|WriteType::BATCHING,
+     *     batchSize?: int,
+     *     retryInterval?: int,
+     *     maxRetries?: int,
+     *     maxRetryDelay?: int,
+     *     maxRetryTime?: int,
+     *     exponentialBase?: int,
+     *     jitterInterval?: int,
+     * }|null $writeOptions Array containing the write parameters (See above)
      */
     public function __construct(?array $writeOptions = null)
     {

--- a/src/InfluxDB2/WritePayloadSerializer.php
+++ b/src/InfluxDB2/WritePayloadSerializer.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace InfluxDB2;
 
 use InfluxDB2\Model\WritePrecision;
@@ -19,11 +18,11 @@ class WritePayloadSerializer
      */
     public static function generatePayload($data, ?string $precision = null, ?string $bucket = null, ?string $org = null, ?int $writeType = null)
     {
-        if ($data == null || empty($data)) {
+        if (empty($data)) {
             return null;
         }
         if (is_string($data)) {
-            if (WriteType::BATCHING == $writeType) {
+            if (WriteType::BATCHING === $writeType) {
                 return new BatchItem(new BatchItemKey($bucket, $org, $precision), $data);
             } else {
                 return $data;
@@ -47,7 +46,7 @@ class WritePayloadSerializer
             }
 
             // remove last new line
-            if (isset($payload) && trim($payload) !== '') {
+            if (trim($payload) !== '') {
                 $payload = rtrim($payload, "\n");
             }
 

--- a/src/InfluxDB2/WriteRetry.php
+++ b/src/InfluxDB2/WriteRetry.php
@@ -9,17 +9,14 @@ use Http\Client\Exception\NetworkException;
  */
 class WriteRetry
 {
-    private $maxRetries;
-    private $retryInterval;
-    private $maxRetryDelay;
-    private $exponentialBase;
-    private $jitterInterval;
-    private $maxRetryTime;
-    private $retryTimout;
-    /**
-     * @var array
-     */
-    private $options;
+    private int $maxRetries;
+    private int $retryInterval;
+    private int $maxRetryDelay;
+    private int $exponentialBase;
+    private int $jitterInterval;
+    private int $maxRetryTime;
+    private int $retryTimeout;
+    private ?ClientOptions $options;
 
     /**
      * WriteRetry constructor.
@@ -38,7 +35,7 @@ class WriteRetry
      *
      * @param int $maxRetryTime maximum total time when retrying write in milliseconds
      * @param int $jitterInterval the number of milliseconds before the data is written increased by a random amount
-     * @param array $options Client options with logFile.
+     * @param ClientOptions|null $options Client options with logFile.
      */
     public function __construct(
         int $maxRetries = 5,
@@ -47,7 +44,7 @@ class WriteRetry
         int $exponentialBase = 2,
         int $maxRetryTime = 180000,
         int $jitterInterval = 0,
-        array $options = []
+        ?ClientOptions $options = null
     ) {
         $this->maxRetries = $maxRetries;
         $this->retryInterval = $retryInterval;
@@ -57,14 +54,14 @@ class WriteRetry
         $this->jitterInterval = $jitterInterval;
         $this->options = $options;
 
-        //retry timout
-        $this->retryTimout = microtime(true) * 1000 + $maxRetryTime;
+        //retry timeout
+        $this->retryTimeout = (int) microtime(true) * 1000 + $maxRetryTime;
     }
 
     /**
      * @throws ApiException
      */
-    public function retry($callable, $attempts = 0)
+    public function retry($callable, int $attempts = 0)
     {
         try {
             return call_user_func($callable);
@@ -81,13 +78,13 @@ class WriteRetry
             }
 
             // throws exception when max retry time is exceeded
-            if (microtime(true) * 1000 > $this->retryTimout) {
+            if (microtime(true) * 1000 > $this->retryTimeout) {
                 DefaultApi::log("ERROR", "Maximum retry time $this->maxRetryTime ms exceeded", $this->options);
                 throw $e;
             }
 
             $headers = $e->getResponseHeaders();
-            if ($headers != null && array_key_exists('Retry-After', $headers)) {
+            if ($headers !== null && array_key_exists('Retry-After', $headers)) {
                 //jitter add in microseconds
                 $jitterMicro = rand(0, $this->jitterInterval) * 1000;
                 $timeout = (int)$headers['Retry-After'][0] * 1000000.0 + $jitterMicro;
@@ -99,7 +96,7 @@ class WriteRetry
 
             $message = "The retryable error occurred during writing of data. Reason: '$error'. Retry in: {$timeoutInSec}s.";
             DefaultApi::log("WARNING", $message, $this->options);
-            usleep($timeout);
+            usleep((int) $timeout);
             $this->retry($callable, $attempts);
         }
     }
@@ -107,14 +104,14 @@ class WriteRetry
     public function isRetryable(ApiException $e): bool
     {
         $code = $e->getCode();
-        if (($code == null || $code < 429) &&
+        if (($code === null || $code < 429) &&
             !($e->getPrevious() instanceof NetworkException)) {
             return false;
         }
         return true;
     }
 
-    public function getBackoffTime(int $attempt)
+    public function getBackoffTime(int $attempt): float
     {
         $range_start = $this->retryInterval;
         $range_stop = $this->retryInterval * $this->exponentialBase;

--- a/src/InfluxDB2/WriteType.php
+++ b/src/InfluxDB2/WriteType.php
@@ -4,6 +4,6 @@ namespace InfluxDB2;
 
 class WriteType
 {
-    const SYNCHRONOUS = 1;
-    const BATCHING = 2;
+    public const SYNCHRONOUS = 1;
+    public const BATCHING = 2;
 }

--- a/src/InfluxDB2/Writer.php
+++ b/src/InfluxDB2/Writer.php
@@ -1,11 +1,9 @@
 <?php
 
-
 namespace InfluxDB2;
 
 interface Writer
 {
-
     /**
      * Write data
      *
@@ -31,5 +29,5 @@ interface Writer
      * array, Point, string
      * @throws \Throwable
      */
-    public function write($data);
+    public function write($data): void;
 }

--- a/tests/BasicTest.php
+++ b/tests/BasicTest.php
@@ -5,14 +5,14 @@ namespace InfluxDB2Test;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
-use GuzzleHttp\Psr7\Request;
-use GuzzleHttp\Psr7\Response;
 use InfluxDB2\Client;
 use InfluxDB2\Model\WritePrecision;
 use InfluxDB2\QueryApi;
 use InfluxDB2\WriteApi;
 use InfluxDB2\WriteType;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * Parent class for all units tests that uses mocked InfluxDB server
@@ -20,16 +20,12 @@ use PHPUnit\Framework\TestCase;
  */
 abstract class BasicTest extends TestCase
 {
-    /** @var Client */
-    protected $client;
-    /** @var WriteApi */
-    protected $writeApi;
-    /** @var QueryApi */
-    protected $queryApi;
-    /** @var MockHandler */
-    protected $mockHandler;
-    /** @var array<int, array{request: Request, response: Response, error: mixed, options: array<mixed>}> */
-    protected $requests;
+    protected Client $client;
+    protected WriteApi $writeApi;
+    protected QueryApi $queryApi;
+    protected MockHandler $mockHandler;
+    /** @var array<int, array{request: RequestInterface, response: ResponseInterface|null, error: mixed, options: array<mixed>}> */
+    protected array $requests;
 
     /**
      * @before

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -60,7 +60,10 @@ class ClientTest extends IntegrationBaseTestCase
 
     public function test_debug(): void
     {
-        $logFilePath = stream_get_meta_data(tmpfile())['uri'];
+        $logFileMetadata = stream_get_meta_data(tmpfile());
+        self::assertArrayHasKey('uri', $logFileMetadata);
+        $logFilePath = $logFileMetadata['uri'];
+        self::assertIsString($logFilePath);
         $this->client->close();
         $this->client = new Client([
             "url" => "http://localhost:8086",
@@ -72,7 +75,9 @@ class ClientTest extends IntegrationBaseTestCase
         $tables = $this->client->createQueryApi()->query("buckets()", "my-org");
         self::assertCount(1, $tables);
 
-        self::assertStringContainsString('Authorization: ***', file_get_contents($logFilePath));
+        $logFileContents = file_get_contents($logFilePath);
+        self::assertIsString($logFileContents);
+        self::assertStringContainsString('Authorization: ***', $logFileContents);
         unlink($logFilePath);
     }
 }

--- a/tests/DefaultApiTest.php
+++ b/tests/DefaultApiTest.php
@@ -2,12 +2,12 @@
 
 namespace InfluxDB2Test;
 
-use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use InfluxDB2\ApiException;
 use InfluxDB2\Client;
 use InfluxDB2\Model\WritePrecision;
 use InvalidArgumentException;
+use Psr\Http\Message\RequestInterface;
 use ReflectionObject;
 
 require_once('BasicTest.php');
@@ -21,6 +21,7 @@ class DefaultApiTest extends BasicTest
 
         $request = $this->mockHandler->getLastRequest();
 
+        self::assertInstanceOf(RequestInterface::class, $request);
         self::assertStringStartsWith(
             'influxdb-client-php/',
             strval($request->getHeader("User-Agent")[0])
@@ -34,6 +35,7 @@ class DefaultApiTest extends BasicTest
 
         $request = $this->mockHandler->getLastRequest();
 
+        self::assertInstanceOf(RequestInterface::class, $request);
         self::assertEquals('http://localhost:8086/api/v2/write?org=my-org&bucket=my-bucket&precision=ns', strval($request->getUri()));
 
         $this->tearDown();
@@ -44,6 +46,7 @@ class DefaultApiTest extends BasicTest
 
         $request = $this->mockHandler->getLastRequest();
 
+        self::assertInstanceOf(RequestInterface::class, $request);
         self::assertEquals('http://localhost:8086/api/v2/write?org=my-org&bucket=my-bucket&precision=ns', strval($request->getUri()));
     }
 
@@ -70,7 +73,7 @@ class DefaultApiTest extends BasicTest
     {
         $this->mockHandler->append(new Response(204));
 
-        $this->writeApi->options["org"] = '';
+        $this->writeApi->options->org = '';
 
         $this->expectException(InvalidArgumentException::class);
 
@@ -81,6 +84,7 @@ class DefaultApiTest extends BasicTest
     {
         $guzzle = $this->property_value($this->property_value($this->writeApi->http, 'client'), 'httpClient');
 
+        self::assertInstanceOf(\GuzzleHttp\Client::class, $guzzle);
         self::assertTrue($guzzle->getConfig()['verify']);
     }
 
@@ -98,6 +102,7 @@ class DefaultApiTest extends BasicTest
 
         $guzzle = $this->property_value($this->property_value($client->createQueryApi()->http, 'client'), 'httpClient');
 
+        self::assertInstanceOf(\GuzzleHttp\Client::class, $guzzle);
         self::assertFalse($guzzle->getConfig()['verify']);
 
         $client->close();
@@ -141,10 +146,10 @@ class DefaultApiTest extends BasicTest
     }
 
     /**
-     * @param Request $request with headers
+     * @param RequestInterface $request with headers
      * @return string Authorization headers
      */
-    private function getHeader(Request $request): string
+    private function getHeader(RequestInterface $request): string
     {
         return implode(' ', $request->getHeaders()['Authorization']);
     }

--- a/tests/FluxCsvParserTest.php
+++ b/tests/FluxCsvParserTest.php
@@ -3,6 +3,7 @@
 namespace InfluxDB2Test;
 
 use Exception;
+use InfluxDB2\FluxColumn;
 use InfluxDB2\FluxCsvParser;
 use InfluxDB2\FluxCsvParserException;
 use InfluxDB2\FluxQueryError;
@@ -465,6 +466,10 @@ class FluxCsvParserTest extends TestCase
         self::assertEquals(25.3, $tables[0]->records[0]->row[7]);
     }
 
+    /**
+     * @param array<int, FluxColumn> $columnHeaders
+     * @param array<int, bool> $values
+     */
     private function assertColumns(array $columnHeaders, array $values): void
     {
         $i = 0;
@@ -474,6 +479,9 @@ class FluxCsvParserTest extends TestCase
         }
     }
 
+    /**
+     * @param array<FluxTable> $tables
+     */
     private function assertMultipleRecords(array $tables): void
     {
         #Record 1

--- a/tests/ITBucketServiceTest.php
+++ b/tests/ITBucketServiceTest.php
@@ -3,7 +3,10 @@
 namespace InfluxDB2Test;
 
 use InfluxDB2\ApiException;
+use InfluxDB2\Model\Bucket;
 use InfluxDB2\Model\BucketRetentionRules;
+use InfluxDB2\Model\Buckets;
+use InfluxDB2\Model\HealthCheck;
 use InfluxDB2\Model\PostBucketRequest;
 use InfluxDB2\ObjectSerializer;
 use InfluxDB2\Service\BucketsService;
@@ -20,6 +23,7 @@ class ITBucketServiceTest extends IntegrationBaseTestCase
     {
         $healthService = $this->client->createService(HealthService::class);
         $healthCheck = $healthService->getHealth();
+        self::assertInstanceOf(HealthCheck::class, $healthCheck);
         self::assertEquals("influxdb", $healthCheck->getName());
         self::assertEquals("ready for queries and writes", $healthCheck->getMessage());
     }
@@ -64,10 +68,11 @@ class ITBucketServiceTest extends IntegrationBaseTestCase
 
     public function testBucketService(): void
     {
-        /** @var BucketsService $bucketsService */
         $bucketsService = $this->client->createService(BucketsService::class);
-        $buckets = $bucketsService->getBuckets(null, null, 100, null)->getBuckets();
-        foreach ($buckets as $bucket) {
+        self::assertInstanceOf(BucketsService::class, $bucketsService);
+        $buckets = $bucketsService->getBuckets(null, null, 100, null);
+        self::assertInstanceOf(Buckets::class, $buckets);
+        foreach ($buckets->getBuckets() as $bucket) {
             self::assertNotEmpty($bucket->getName());
             self::assertNotEmpty($bucket->getId());
         }
@@ -75,8 +80,8 @@ class ITBucketServiceTest extends IntegrationBaseTestCase
 
     public function testBucketServiceCreateBucket(): void
     {
-        /** @var BucketsService $bucketsService */
         $bucketsService = $this->client->createService(BucketsService::class);
+        self::assertInstanceOf(BucketsService::class, $bucketsService);
 
         $rule = new BucketRetentionRules();
         $rule->setEverySeconds(3600);
@@ -90,12 +95,15 @@ class ITBucketServiceTest extends IntegrationBaseTestCase
         //create bucket
         $respBucket = $bucketsService->postBuckets($bucketRequest);
         print $respBucket;
+        self::assertInstanceOf(Bucket::class, $respBucket);
         self::assertEquals($bucketName, $respBucket->getName());
 
         //find bucket
-        $buckets = $bucketsService->getBuckets(null, null, 100, null)->getBuckets();
+        $buckets = $bucketsService->getBuckets(null, null, 100, null);
+        self::assertInstanceOf(Buckets::class, $buckets);
         $findBucket = null;
-        foreach ($buckets as $bucket) {
+        foreach ($buckets->getBuckets() as $bucket) {
+            self::assertInstanceOf(Bucket::class, $bucket);
             self::assertNotEmpty($bucket->getName());
             self::assertNotEmpty($bucket->getId());
             if ($bucket->getId() === $respBucket->getId()) {

--- a/tests/ITTaskServiceTest.php
+++ b/tests/ITTaskServiceTest.php
@@ -2,6 +2,7 @@
 
 namespace InfluxDB2Test;
 
+use InfluxDB2\Model\Task;
 use InfluxDB2\Model\TaskCreateRequest;
 use InfluxDB2\Service\TasksService;
 
@@ -14,8 +15,8 @@ class ITTaskServiceTest extends IntegrationBaseTestCase
 {
     public function testCreateTask(): void
     {
-        /** @var TasksService $taskService */
         $taskService = $this->client->createService(TasksService::class);
+        self::assertInstanceOf(TasksService::class, $taskService);
 
         $flux = "option task = {
   name: \"task-name\",
@@ -31,6 +32,7 @@ from(bucket: \"telegraf\") |> range(start: -1h)
 
         $task = $taskService->postTasks($taskCreateRequest);
 
+        self::assertInstanceOf(Task::class, $task);
         self::assertEquals("task-name", $task->getName());
     }
 }

--- a/tests/ITUsersServiceTest.php
+++ b/tests/ITUsersServiceTest.php
@@ -2,6 +2,8 @@
 
 namespace InfluxDB2Test;
 
+use InfluxDB2\Model\User;
+use InfluxDB2\Model\Users;
 use InfluxDB2\Service\UsersService;
 
 require_once('IntegrationBaseTestCase.php');
@@ -13,10 +15,12 @@ class ITUsersServiceTest extends IntegrationBaseTestCase
 {
     public function testUserService(): void
     {
-        /** @var UsersService $usersService */
         $usersService = $this->client->createService(UsersService::class);
-        $users = $usersService->getUsers()->getUsers();
-        foreach ($users as $user) {
+        self::assertInstanceOf(UsersService::class, $usersService);
+        $users = $usersService->getUsers();
+        self::assertInstanceOf(Users::class, $users);
+        foreach ($users->getUsers() as $user) {
+            self::assertInstanceOf(User::class, $user);
             self::assertNotEmpty($user->getName());
             self::assertNotEmpty($user->getId());
             self::assertNotEmpty($user->getLinks()->getSelf());

--- a/tests/IntegrationBaseTestCase.php
+++ b/tests/IntegrationBaseTestCase.php
@@ -4,14 +4,14 @@ namespace InfluxDB2Test;
 
 use InfluxDB2\Client;
 use InfluxDB2\Model\Organization;
+use InfluxDB2\Model\Organizations;
 use InfluxDB2\Model\WritePrecision;
 use InfluxDB2\Service\OrganizationsService;
 use PHPUnit\Framework\TestCase;
 
 class IntegrationBaseTestCase extends TestCase
 {
-    /** @var Client */
-    public $client;
+    public Client $client;
     /**
      * @var array{
      *     url: string,
@@ -31,7 +31,7 @@ class IntegrationBaseTestCase extends TestCase
      *     tags?: array<string, string>,
      * } $options
      */
-    public $options;
+    public array $options;
 
     public function setUp(): void
     {
@@ -49,10 +49,11 @@ class IntegrationBaseTestCase extends TestCase
 
     public function findMyOrg(): ?Organization
     {
-        /** @var OrganizationsService $orgService */
         $orgService = $this->client->createService(OrganizationsService::class);
-        $orgs = $orgService->getOrgs()->getOrgs();
-        foreach ($orgs as $org) {
+        self::assertInstanceOf(OrganizationsService::class, $orgService);
+        $orgs = $orgService->getOrgs();
+        self::assertInstanceOf(Organizations::class, $orgs);
+        foreach ($orgs->getOrgs() as $org) {
             if ($org->getName() === $this->options["org"]) {
                 return $org;
             }

--- a/tests/InvokableScriptsApiTest.php
+++ b/tests/InvokableScriptsApiTest.php
@@ -2,6 +2,8 @@
 
 namespace InfluxDB2Test;
 
+use InfluxDB2\InvokableScriptsApi;
+
 require_once('BasicTest.php');
 
 /**
@@ -14,6 +16,6 @@ class InvokableScriptsApiTest extends BasicTest
     {
         $invokableScriptsApi = $this->client->createInvokableScriptsApi();
 
-        self::assertNotNull($invokableScriptsApi);
+        self::assertInstanceOf(InvokableScriptsApi::class, $invokableScriptsApi);
     }
 }

--- a/tests/PointSettingsTest.php
+++ b/tests/PointSettingsTest.php
@@ -11,8 +11,7 @@ class PointSettingsTest extends TestCase
     private const ID_TAG = "132-987-655";
     private const CUSTOMER_TAG = "California Miner";
 
-    /** @var Client */
-    private $client;
+    private Client $client;
 
     public function setUp(): void
     {

--- a/tests/QueryApiIntegrationTest.php
+++ b/tests/QueryApiIntegrationTest.php
@@ -15,12 +15,9 @@ use PHPUnit\Framework\TestCase;
  */
 class QueryApiIntegrationTest extends TestCase
 {
-    /** @var Client */
-    private $client;
-    /** @var WriteApi */
-    private $writeApi;
-    /** @var QueryApi */
-    private $queryApi;
+    private Client $client;
+    private WriteApi $writeApi;
+    private QueryApi $queryApi;
 
     /**
      * @before
@@ -39,12 +36,6 @@ class QueryApiIntegrationTest extends TestCase
         $this->queryApi = $this->client->createQueryApi();
     }
 
-    public function testExistsApi(): void
-    {
-        self::assertNotNull($this->writeApi);
-        self::assertNotNull($this->queryApi);
-    }
-
     public function testQueryRaw(): void
     {
         $now = new DateTime();
@@ -55,6 +46,7 @@ class QueryApiIntegrationTest extends TestCase
 
         $result = $this->queryApi->queryRaw($query);
 
+        self::assertIsString($result);
         self::assertStringContainsString(',result,table,_start,_stop,_time,_value,_field,_measurement,location', $result);
         self::assertStringContainsString($measurement, $result);
     }

--- a/tests/QueryApiStreamTest.php
+++ b/tests/QueryApiStreamTest.php
@@ -15,14 +15,10 @@ use PHPUnit\Framework\TestCase;
  */
 class QueryApiStreamTest extends TestCase
 {
-    /** @var Client */
-    private $client;
-    /** @var WriteApi */
-    private $writeApi;
-    /** @var QueryApi */
-    private $queryApi;
-    /** @var DateTime */
-    private $now;
+    private Client $client;
+    private WriteApi $writeApi;
+    private QueryApi $queryApi;
+    private DateTime $now;
 
     /**
      * @before

--- a/tests/QueryApiTest.php
+++ b/tests/QueryApiTest.php
@@ -5,6 +5,7 @@ namespace InfluxDB2Test;
 use DateInterval;
 use DateTime;
 use GuzzleHttp\Psr7\Response;
+use InfluxDB2\FluxTable;
 use InfluxDB2\Model\Query;
 
 require_once('BasicTest.php');

--- a/tests/WriteApiBatchingTest.php
+++ b/tests/WriteApiBatchingTest.php
@@ -43,7 +43,9 @@ class WriteApiBatchingTest extends BasicTest
         $result2 = "h2o_feet,location=coyote_creek level\\ water_level=3.0 3\n"
             . "h2o_feet,location=coyote_creek level\\ water_level=4.0 4";
 
+        self::assertInstanceOf(RequestInterface::class, $this->requests[0]['request']);
         self::assertEquals($result1, $this->requests[0]['request']->getBody());
+        self::assertInstanceOf(RequestInterface::class, $this->requests[1]['request']);
         self::assertEquals($result2, $this->requests[1]['request']->getBody());
     }
 
@@ -101,6 +103,7 @@ class WriteApiBatchingTest extends BasicTest
 
         $request = $this->requests[0]['request'];
 
+        self::assertInstanceOf(RequestInterface::class, $request);
         self::assertEquals(
             'http://localhost:8086/api/v2/write?org=my-org&bucket=my-bucket&precision=ns',
             strval($request->getUri())
@@ -109,6 +112,7 @@ class WriteApiBatchingTest extends BasicTest
 
         $request = $this->requests[1]['request'];
 
+        self::assertInstanceOf(RequestInterface::class, $request);
         self::assertEquals(
             'http://localhost:8086/api/v2/write?org=my-org&bucket=my-bucket&precision=s',
             strval($request->getUri())
@@ -117,6 +121,7 @@ class WriteApiBatchingTest extends BasicTest
 
         $request = $this->requests[2]['request'];
 
+        self::assertInstanceOf(RequestInterface::class, $request);
         self::assertEquals(
             'http://localhost:8086/api/v2/write?org=my-org-a&bucket=my-bucket&precision=ns',
             strval($request->getUri())
@@ -126,6 +131,7 @@ class WriteApiBatchingTest extends BasicTest
 
         $request = $this->requests[3]['request'];
 
+        self::assertInstanceOf(RequestInterface::class, $request);
         self::assertEquals(
             'http://localhost:8086/api/v2/write?org=my-org-a&bucket=my-bucket2&precision=ns',
             strval($request->getUri())
@@ -134,6 +140,7 @@ class WriteApiBatchingTest extends BasicTest
 
         $request = $this->requests[4]['request'];
 
+        self::assertInstanceOf(RequestInterface::class, $request);
         self::assertEquals(
             'http://localhost:8086/api/v2/write?org=my-org-a&bucket=my-bucket&precision=ns',
             strval($request->getUri())
@@ -158,7 +165,6 @@ class WriteApiBatchingTest extends BasicTest
         $request = $this->mockHandler->getLastRequest();
 
         self::assertInstanceOf(RequestInterface::class, $request);
-
         self::assertEquals(
             'http://localhost:8086/api/v2/write?org=my-org&bucket=my-bucket&precision=ns',
             strval($request->getUri())
@@ -185,6 +191,7 @@ class WriteApiBatchingTest extends BasicTest
         self::assertCount(2, $this->requests);
         $request = $this->mockHandler->getLastRequest();
 
+        self::assertInstanceOf(RequestInterface::class, $request);
         self::assertEquals(
             'http://localhost:8086/api/v2/write?org=my-org&bucket=my-bucket&precision=ns',
             strval($request->getUri())
@@ -211,6 +218,7 @@ class WriteApiBatchingTest extends BasicTest
         self::assertCount(2, $this->requests);
         $request = $this->mockHandler->getLastRequest();
 
+        self::assertInstanceOf(RequestInterface::class, $request);
         self::assertEquals(
             'http://localhost:8086/api/v2/write?org=my-org&bucket=my-bucket&precision=ns',
             strval($request->getUri())
@@ -243,7 +251,7 @@ class WriteApiBatchingTest extends BasicTest
     public function testRetryCount(): void
     {
         $this->mockHandler->append(
-        // regular call
+            // regular call
             new Response(429),
             // retry
             new Response(429),
@@ -350,6 +358,7 @@ class WriteApiBatchingTest extends BasicTest
         self::assertCount(2, $this->requests);
 
         $message = file_get_contents("log_test.txt");
+        self::assertIsString($message);
         self::assertStringContainsString("The retryable error occurred during writing of data. Reason: 'org 04014de4ed590000 has exceeded limited_write plan limit'. Retry in: 3s.", $message);
     }
 }

--- a/tests/WriteApiIntegrationTest.php
+++ b/tests/WriteApiIntegrationTest.php
@@ -14,10 +14,8 @@ use PHPUnit\Framework\TestCase;
  */
 class WriteApiIntegrationTest extends TestCase
 {
-    /** @var Client */
-    private $client;
-    /** @var WriteApi */
-    private $writeApi;
+    private Client $client;
+    private WriteApi $writeApi;
 
     /**
      * @before
@@ -35,16 +33,11 @@ class WriteApiIntegrationTest extends TestCase
         $this->writeApi = $this->client->createWriteApi();
     }
 
-    public function testExistsWriteApi(): void
-    {
-        self::assertNotNull($this->writeApi);
-    }
-
     public function testWriteApiWriteRaw(): void
     {
         $payload = 'h2o_feet,location=coyote_creek water_level=2.0 2';
-        $response = $this->writeApi->writeRaw($payload);
-        self::assertNull($response);
+        $this->writeApi->writeRaw($payload);
+        self::expectNotToPerformAssertions();
     }
 
     public function testWriteArray(): void
@@ -60,14 +53,14 @@ class WriteApiIntegrationTest extends TestCase
             'time' => 123
         ];
 
-        $response = $this->writeApi->write($data, WritePrecision::S, "my-bucket", "my-org");
-        self::assertNull($response);
+        $this->writeApi->write($data, WritePrecision::S, "my-bucket", "my-org");
+        self::expectNotToPerformAssertions();
     }
 
     public function testBatchingWrite(): void
     {
         $writeApi = $this->client->createWriteApi(
-            ["writeType"=>WriteType::BATCHING, 'batchSize'=>3]
+            ["writeType" => WriteType::BATCHING, 'batchSize' => 3]
         );
 
         $data = ['name' => 'cpu',
@@ -91,9 +84,8 @@ class WriteApiIntegrationTest extends TestCase
         $writeApi->write($p5);
         $writeApi->write($p6);
 
-        self::assertNotNull($writeApi);
-
         $this->client->close();
+        self::expectNotToPerformAssertions();
     }
 
     public function testWriteArrayOfPoint(): void
@@ -109,8 +101,8 @@ class WriteApiIntegrationTest extends TestCase
 
         $data = array($point1, $point2);
 
-        $response = $this->writeApi->write($data, WritePrecision::S, "my-bucket", "my-org");
-        self::assertNull($response);
+        $this->writeApi->write($data, WritePrecision::S, "my-bucket", "my-org");
+        self::expectNotToPerformAssertions();
     }
 
     public function testWriteArrayOfArray(): void
@@ -139,7 +131,7 @@ class WriteApiIntegrationTest extends TestCase
 
         $data = array($data1, $data2);
 
-        $response = $this->writeApi->write($data, WritePrecision::S, "my-bucket", "my-org");
-        self::assertNull($response);
+        $this->writeApi->write($data, WritePrecision::S, "my-bucket", "my-org");
+        self::expectNotToPerformAssertions();
     }
 }

--- a/tests/WriteApiTest.php
+++ b/tests/WriteApiTest.php
@@ -10,6 +10,7 @@ use InfluxDB2\Client;
 use InfluxDB2\Model\WritePrecision;
 use InfluxDB2\Point;
 use InfluxDB2\WriteRetry;
+use Psr\Http\Message\RequestInterface;
 
 require_once('BasicTest.php');
 
@@ -36,6 +37,7 @@ class WriteApiTest extends BasicTest
 
         $request = $this->mockHandler->getLastRequest();
 
+        self::assertInstanceOf(RequestInterface::class, $request);
         self::assertEquals(
             'http://localhost:8086/api/v2/write?org=my-org&bucket=my-bucket&precision=ns',
             strval($request->getUri())
@@ -55,6 +57,7 @@ class WriteApiTest extends BasicTest
 
         $request = $this->mockHandler->getLastRequest();
 
+        self::assertInstanceOf(RequestInterface::class, $request);
         self::assertEquals(
             'http://localhost:8086/api/v2/write?org=my-org&bucket=my-bucket&precision=ns',
             strval($request->getUri())
@@ -75,6 +78,7 @@ class WriteApiTest extends BasicTest
 
         $request = $this->mockHandler->getLastRequest();
 
+        self::assertInstanceOf(RequestInterface::class, $request);
         self::assertEquals(
             'http://localhost:8086/api/v2/write?org=my-org&bucket=my-bucket&precision=ns',
             strval($request->getUri())
@@ -103,6 +107,7 @@ class WriteApiTest extends BasicTest
             . "h2o,location=europe level=2i\n"
             . "h2o,host=aws,region=us level=5i,saturation=\"99%\" 123";
 
+        self::assertInstanceOf(RequestInterface::class, $request);
         self::assertEquals(
             'http://localhost:8086/api/v2/write?org=my-org&bucket=my-bucket&precision=ns',
             strval($request->getUri())
@@ -117,11 +122,15 @@ class WriteApiTest extends BasicTest
 
         $request = $this->mockHandler->getLastRequest();
 
+        self::assertInstanceOf(RequestInterface::class, $request);
         self::assertEquals(
             'http://localhost:8086/api/v2/write?org=my-org&bucket=my-bucket&precision=ns',
             strval($request->getUri())
         );
-        self::assertEquals('Token my-token', implode(' ', $request->getHeaders()['Authorization']));
+        $requestHeaders = $request->getHeaders();
+        self::assertArrayHasKey('Authorization', $requestHeaders);
+        self::assertCount(1, $requestHeaders['Authorization']);
+        self::assertEquals('Token my-token', implode(' ', $requestHeaders['Authorization']));
     }
 
     public function testWithoutData(): void
@@ -168,6 +177,7 @@ class WriteApiTest extends BasicTest
 
         $request = $this->mockHandler->getLastRequest();
 
+        self::assertInstanceOf(RequestInterface::class, $request);
         self::assertEquals(
             'http://localhost:8086/api/v2/write?org=my-org&bucket=my-bucket&precision=ns',
             strval($request->getUri())
@@ -195,6 +205,7 @@ class WriteApiTest extends BasicTest
 
         $request = $this->mockHandler->getLastRequest();
 
+        self::assertInstanceOf(RequestInterface::class, $request);
         self::assertEquals(
             'http://localhost:8086/api/v2/write?org=my-org&bucket=my-bucket&precision=ns',
             strval($request->getUri())
@@ -230,6 +241,7 @@ class WriteApiTest extends BasicTest
             . "h2o,customer=California\ Miner,data_center=LA,id=132-987-655,location=europe level=2i\n"
             . "h2o,customer=California\ Miner,data_center=LA,host=aws,id=132-987-655,region=us level=5i,saturation=\"99%\" 123";
 
+        self::assertInstanceOf(RequestInterface::class, $request);
         self::assertEquals(
             'http://localhost:8086/api/v2/write?org=my-org&bucket=my-bucket&precision=ns',
             strval($request->getUri())
@@ -253,6 +265,7 @@ class WriteApiTest extends BasicTest
 
         $request = $this->mockHandler->getLastRequest();
 
+        self::assertInstanceOf(RequestInterface::class, $request);
         self::assertEquals(
             'http://localhost:8086/api/v2/write?org=my-org&bucket=my-bucket&precision=ns',
             strval($request->getUri())
@@ -266,7 +279,7 @@ class WriteApiTest extends BasicTest
     public function testRetryCount(): void
     {
         $this->mockHandler->append(
-        // regular call
+            // regular call
             new Response(429),
             // retry
             new Response(429),
@@ -298,7 +311,7 @@ class WriteApiTest extends BasicTest
     public function testRetryMaxTime(): void
     {
         $this->mockHandler->append(
-        // regular call
+            // regular call
             new Response(429),
             // retry
             new Response(429),
@@ -377,7 +390,7 @@ class WriteApiTest extends BasicTest
         try {
             $writeApi->write($point);
         } catch (ApiException $e) {
-            self::assertEquals(ConnectException::class, get_class($e->getPrevious()));
+            self::assertInstanceOf(ConnectException::class, $e->getPrevious());
             throw $e;
         }
     }

--- a/tests/WriteUdpTest.php
+++ b/tests/WriteUdpTest.php
@@ -3,6 +3,7 @@
 namespace InfluxDB2Test;
 
 use InfluxDB2\Client;
+use InfluxDB2\ClientOptions;
 use InfluxDB2\Model\WritePrecision;
 use InfluxDB2\Point;
 use InfluxDB2\UdpWriter;
@@ -53,7 +54,9 @@ class WriteUdpTest extends TestCase
         }
         return $this->getMockBuilder(UdpWriter::class)
             ->onlyMethods(['writeSocket'])
-            ->setConstructorArgs([$this->baseConfig + ['udpPort' => 1000]])
+            ->setConstructorArgs([
+                ClientOptions::fromArray($this->baseConfig + ['udpPort' => 1000]),
+            ])
             ->getMock();
     }
 
@@ -83,7 +86,7 @@ class WriteUdpTest extends TestCase
     {
         $writer = $this->getWriterMock();
         $buffer = '';
-        $writer->method('writeSocket')->willReturnCallback(function ($data) use (&$buffer) {
+        $writer->method('writeSocket')->willReturnCallback(function ($data) use (&$buffer): void {
             $buffer = $data;
         });
         $writer->write('h2o,location=west value=33i 15');
@@ -101,7 +104,7 @@ class WriteUdpTest extends TestCase
 
         $writer = $this->getWriterMock();
         $buffer = '';
-        $writer->method('writeSocket')->willReturnCallback(function ($data) use (&$buffer) {
+        $writer->method('writeSocket')->willReturnCallback(function ($data) use (&$buffer): void {
             $buffer = $data;
         });
         $writer->write($array);


### PR DESCRIPTION
## Proposed Changes

Added PHP 7.4 typehints, fixed most of issues reported by PHPStan, set PHP 7.4 as minimal supported PHP version.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [ ] A test has been added if appropriate
- [x] `make test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
